### PR TITLE
Add season info (bottom-right corner) to Episodes view

### DIFF
--- a/720p/Viewtype_Episode.xml
+++ b/720p/Viewtype_Episode.xml
@@ -274,7 +274,17 @@
           <label>$INFO[Container(514).NumItems,, [LOWERCASE]$LOCALIZE[20360][/LOWERCASE]]</label>
         </control>
       </control>
-
+        <control type="label">
+          <posx>1270</posx>
+          <posy>678</posy>
+          <width>500</width>
+          <height>25</height>
+          <font>Font_Reg24</font>
+          <textcolor>d0FFFFFF</textcolor>
+          <align>right</align>
+          <aligny>center</aligny>
+          <label>$INFO[ListItem.Season,$LOCALIZE[20373] ]</label>
+        </control>
     </control>
   </include>
 </includes>


### PR DESCRIPTION
Hi BigNoid,

This patch adds the season info to the bottom right corner of the "Episode" view. I have tried with all my series and icons usually do not occupy the entire screen so there is space for this information there. 

I also thought about adding the season info to all episodes in the list (together with the release date and the rating) but at the end I seem to prefer this solution.

Regards,
