### PR TITLE
Move and scale logo down a bit as it might overlap show titles

### DIFF
--- a/720p/Viewtype_Episode.xml
+++ b/720p/Viewtype_Episode.xml
@@ -259,9 +259,9 @@
       </control>
       <control type="image">
         <posx>974</posx>
-        <posy>550</posy>
+        <posy>560</posy>
         <width>266</width>
-        <height>103</height>
+        <height>95</height>
         <aspectratio>keep</aspectratio>
         <fadetime>400</fadetime>
         <texture background="true">$INFO[ListItem.path,,../logo.png]</texture>


### PR DESCRIPTION
Hi BigNoid,

Please find here an small fix for your new Episode view (which I still love :-) I found out that for shows with many episodes, the logo on the bottom right corner overlaps the episode title if the title is long enough. A small reduction of it just fixes it. 

Regards,
