### PR TITLE
Fixed: Dutch translation

### DIFF
--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -401,7 +401,7 @@
   <string id="31505">APPS</string>
   <string id="31506">SYSTEEM</string>
   <string id="31507">ADD-ONS</string>
-  <string id="31508">SLUIT AF</string>
+  <string id="31508">AFSLUITEN</string>
   <string id="31509">FAVORIETEN</string>
   <string id="31510">WEER</string>
   <string id="31511">SPEEL SCHIJF</string>


### PR DESCRIPTION
Didn't like it was translated now and it's better looking if it's one word.
