### PR TITLE
Changes in the Greek fontsets only, improving the Greek text appearance.

### DIFF
--- a/720p/Font.xml
+++ b/720p/Font.xml
@@ -1049,7 +1049,7 @@
     </font>
     <font>
       <name>Font_Reg21_Caps</name>
-      <filename>Ubuntu-R_CAPS.ttf</filename>
+      <filename>Ubuntu-B_CAPS.ttf</filename>
       <size>21</size>
     </font>
     <font>
@@ -1074,8 +1074,8 @@
     </font>
     <font>
       <name>Font_Reg38_Caps</name>
-      <filename>Ubuntu-R_CAPS.ttf</filename>
-      <size>38</size>
+      <filename>Ubuntu-B_CAPS.ttf</filename>
+      <size>37</size>
     </font>
   </fontset>
   <fontset id="Greek Light" idloc="31973" unicode="true">
@@ -1309,7 +1309,7 @@
     </font>
     <font>
       <name>Font_Reg21_Caps</name>
-      <filename>Ubuntu-L_CAPS.ttf</filename>
+      <filename>Ubuntu-M_CAPS.ttf</filename>
       <size>21</size>
     </font>
     <font>
@@ -1334,8 +1334,8 @@
     </font>
     <font>
       <name>Font_Reg38_Caps</name>
-      <filename>Ubuntu-L_CAPS.ttf</filename>
-      <size>38</size>
+      <filename>Ubuntu-M_CAPS.ttf</filename>
+      <size>37</size>
     </font>
   </fontset>
 </fonts>


### PR DESCRIPTION
Minor changes in the Greek fontsets only. Movie titles are shown in uppercase, making Greek titled movies that end with "s" appear weird, because the latter "s" ("ς") is lowercase in both cases. Altering the fonts themselves causes changes throughout all the menus, so this is the simplest way to fix the problem.
