### PR TITLE
Changes in Greek fontsets

### DIFF
--- a/720p/Font.xml
+++ b/720p/Font.xml
@@ -1029,7 +1029,7 @@
     </font>
     <font>
       <name>Font_Reg17_Caps</name>
-      <filename>Ubuntu-R_CAPS.ttf</filename>
+      <filename>Ubuntu-R.ttf</filename>
       <size>17</size>
     </font>
     <font>


### PR DESCRIPTION
This solves, in part, the latter "s" ("ς") problem with the Greek text (it is always in lowercase). The other part of the fix is to edit the particular letter in the fonts themselves, like I did here: https://rapidshare.com/files/3123054771/Fonts_-_Greek_fix.rar
