### PR TITLE
Fix position home widget latest movies

### DIFF
--- a/720p/IncludesHomeRecentlyAdded.xml
+++ b/720p/IncludesHomeRecentlyAdded.xml
@@ -282,9 +282,9 @@
 				<visible>Control.HasFocus(8000)</visible>
         <visible>Container(9000).Hasfocus(10)</visible>
         <posx>-2033</posx>
-				<posy>-35</posy>
+				<posy>-5</posy>
 				<animation effect="slide" start="0,0" end="1020,0" time="500" easing="inout" tween="cubic" condition="Control.HasFocus(8000)">Conditional</animation>
-				<animation effect="slide" time="200" start="0,0" end="0,30" condition="Skin.HasSetting(lowermainmenu)+Skin.HasSetting(totalshomehigh)">Conditional</animation>
+				<animation effect="slide" time="200" start="0,0" end="0,-30" condition="Skin.HasSetting(lowermainmenu)">Conditional</animation>
 				<control type="group">
 					<posx>159</posx>
 					<control type="image">


### PR DESCRIPTION
Hi BigNoid,

Using the main menu in the lower position makes the recently added home widget to overlap (when in focus) some of the controls (basically the movie totals db info or the "see trailer" dialog). I have modified a conditional animation to move the control a little bit if the lowermainmenu skin settings is true. 

I have also eliminated the depenency with totalshighmenu as I don't really think it affects anything with the lower main menu.

As always, hope the pull helps. Regards,
