### PR TITLE
Shutdown & Shutdown timer to use XBMC's Shutdown settings

### DIFF
--- a/720p/DialogButtonMenu.xml
+++ b/720p/DialogButtonMenu.xml
@@ -36,7 +36,7 @@
         <posy>-26</posy>
         <width>308</width>
         <height>26</height>
-        <texture>dialogs/context_top_shutdown.png</texture>
+        <texture>dialogs/context_top.png</texture>
       </control>
       <control type="button" id="1">
         <description>Exit XBMC</description>
@@ -49,14 +49,14 @@
         <description>Powerdown XBMC</description>
         <label>$LOCALIZE[13016]</label>
         <include>Objects_ContextMenuButton</include>
-        <onclick>XBMC.Powerdown()</onclick>
+        <onclick>Shutdown</onclick>
         <visible>System.CanPowerDown</visible>
       </control>
       <control type="button" id="3">
         <description>Shutdown Timer</description>
         <label>$LOCALIZE[20150]</label>
         <include>Objects_ContextMenuButton</include>
-        <onclick>XBMC.AlarmClock(shutdowntimer,XBMC.Powerdown())</onclick>
+        <onclick>AlarmClock(shutdowntimer,Shutdown)</onclick>
         <visible>!System.HasAlarm(shutdowntimer) + System.CanPowerDown</visible>
       </control>
       <control type="button" id="4">


### PR DESCRIPTION
When I set a shutdown timer I expect it to use the command that I set in the XBMC System Settings. (For me its Suspend.) I just edited so it uses that setting.

Signed-off-by: IsamuDragon isamu.dragon@gmail.com
