### PR TITLE
Fix for TV show custom fanart

### DIFF
--- a/720p/variables.xml
+++ b/720p/variables.xml
@@ -207,7 +207,7 @@
   </variable>
  
   <variable name="VideoExtraFanartVar">
-    <value condition="Container.Content(seasons)+!Skin.HasSetting(extrafanartseasons)">$INFO[ListItem.Path]$INFO[ListItem.Season,season,-fanart.jpg]</value>
+    <value condition="Container.Content(seasons)+!Skin.HasSetting(extrafanartseasons)+!SubString(ListItem.Label,*,left)">$INFO[ListItem.Path]$INFO[ListItem.Season,season,-fanart.jpg]</value>
     <value condition="Container.Content(episodes)+!Skin.HasSetting(extrafanartepisodes)">$INFO[ListItem.Path]$INFO[ListItem.Season,../season,-fanart.jpg]</value>
     <!--<value condition="Container.Content(genres)">$INFO[ListItem.Label,special://skin/extras/genre/video/fanart/,.jpg]</value>-->
     <value condition="System.IdleTime(10)+[[Container.Content(movies)+Skin.HasSetting(extrafanartmovies)]|[Container.Content(tvshows)+Skin.HasSetting(extrafanartseries)]|[Container.Content(seasons)+Skin.HasSetting(extrafanartseasons)]]">$INFO[ListItem.Path,,extrafanart]</value>


### PR DESCRIPTION
If there are images present inside a TV show's folder (such as clearart, logo, banner, etc.), they appear as background in "All Seasons" when extrafanart is disabled, like this: http://img7.imageshack.us/img7/2293/screenshot000fw.png

I think this is caused due to the fact that "All Seasons" is recognized as "*" ("all").
