### PR TITLE
Fix for non 16:9 screen resolutions

### DIFF
--- a/720p/Viewtype_Posters.xml
+++ b/720p/Viewtype_Posters.xml
@@ -25,7 +25,7 @@
               <posy>16</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem9Var]</texture>
             </control>
             <control type="image">
@@ -33,7 +33,7 @@
               <posy>176</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem9Var]</texture>
             </control>
             <control type="image">
@@ -41,7 +41,7 @@
               <posy>0</posy>
               <width>144</width>
               <height>235</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture>thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -69,7 +69,7 @@
               <posy>19</posy>
               <width>129</width>
               <height>194</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem8Var]</texture>
             </control>
             <control type="image">
@@ -77,7 +77,7 @@
               <posy>212</posy>
               <width>129</width>
               <height>193</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem8Var]</texture>
             </control>
             <control type="image">
@@ -85,7 +85,7 @@
               <posy>0</posy>
               <width>173</width>
               <height>283</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -113,7 +113,7 @@
               <posy>22</posy>
               <width>151</width>
               <height>227</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem7Var]</texture>
             </control>
             <control type="image">
@@ -121,7 +121,7 @@
               <posy>248</posy>
               <width>151</width>
               <height>226</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem7Var]</texture>
             </control>
             <control type="image">
@@ -129,7 +129,7 @@
               <posy>0</posy>
               <width>203</width>
               <height>331</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -157,7 +157,7 @@
               <posy>26</posy>
               <width>173</width>
               <height>258</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem6Var]</texture>
             </control>
             <control type="image">
@@ -165,7 +165,7 @@
               <posy>284</posy>
               <width>173</width>
               <height>258</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem6Var]</texture>
             </control>
             <control type="image">
@@ -173,7 +173,7 @@
               <posy>0</posy>
               <width>232</width>
               <height>379</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -201,7 +201,7 @@
               <posy>29</posy>
               <width>195</width>
               <height>292</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem5Var]</texture>
             </control>
             <control type="image">
@@ -209,7 +209,7 @@
               <posy>320</posy>
               <width>195</width>
               <height>292</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem5Var]</texture>
             </control>
             <control type="image">
@@ -217,7 +217,7 @@
               <posy>0</posy>
               <width>262</width>
               <height>427</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -245,7 +245,7 @@
               <posy>32</posy>
               <width>217</width>
               <height>325</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem4Var]</texture>
             </control>
             <control type="image">
@@ -253,7 +253,7 @@
               <posy>356</posy>
               <width>217</width>
               <height>325</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem4Var]</texture>
             </control>
             <control type="image">
@@ -261,7 +261,7 @@
               <posy>0</posy>
               <width>291</width>
               <height>475</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -289,7 +289,7 @@
               <posy>35</posy>
               <width>239</width>
               <height>358</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem3Var]</texture>
             </control>
             <control type="image">
@@ -297,7 +297,7 @@
               <posy>392</posy>
               <width>239</width>
               <height>358</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem3Var]</texture>
             </control>
             <control type="image">
@@ -305,7 +305,7 @@
               <posy>0</posy>
               <width>321</width>
               <height>523</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -333,7 +333,7 @@
               <posy>38</posy>
               <width>261</width>
               <height>391</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem2Var]</texture>
             </control>
             <control type="image">
@@ -341,7 +341,7 @@
               <posy>428</posy>
               <width>261</width>
               <height>391</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem2Var]</texture>
             </control>
             <control type="image">
@@ -349,7 +349,7 @@
               <posy>0</posy>
               <width>350</width>
               <height>571</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -377,7 +377,7 @@
               <posy>41</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem1Var]</texture>
             </control>
             <control type="image">
@@ -385,7 +385,7 @@
               <posy>465</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem1Var]</texture>
             </control>
             <control type="image">
@@ -393,7 +393,7 @@
               <posy>0</posy>
               <width>380</width>
               <height>620</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -424,7 +424,7 @@
               <posy>0</posy>
               <width>380</width>
               <height>620</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay-focus.png</texture>
             </control>
           </control>
@@ -450,7 +450,7 @@
               <posy>0</posy>
               <width>380</width>
               <height>620</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
           </control>
@@ -474,7 +474,7 @@
               <posy>41</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem0Var]</texture>
             </control>
             <control type="image">
@@ -482,7 +482,7 @@
               <posy>465</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem0Var]</texture>
             </control>
             <control type="image">
@@ -490,7 +490,7 @@
               <posy>0</posy>
               <width>380</width>
               <height>620</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay-focus.png</texture>
             </control>
             <control type="image">
@@ -526,7 +526,7 @@
               <posy>16</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem8Var]</texture>
             </control>
             <control type="image">
@@ -534,7 +534,7 @@
               <posy>176</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem8Var]</texture>
             </control>
             <control type="image">
@@ -542,7 +542,7 @@
               <posy>0</posy>
               <width>144</width>
               <height>235</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -570,7 +570,7 @@
               <posy>16</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem7Var]</texture>
             </control>
             <control type="image">
@@ -578,7 +578,7 @@
               <posy>176</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem7Var]</texture>
             </control>
             <control type="image">
@@ -586,7 +586,7 @@
               <posy>0</posy>
               <width>144</width>
               <height>235</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -614,7 +614,7 @@
               <posy>19</posy>
               <width>129</width>
               <height>194</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem6Var]</texture>
             </control>
             <control type="image">
@@ -622,7 +622,7 @@
               <posy>212</posy>
               <width>129</width>
               <height>193</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem6Var]</texture>
             </control>
             <control type="image">
@@ -630,7 +630,7 @@
               <posy>0</posy>
               <width>173</width>
               <height>283</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -658,7 +658,7 @@
               <posy>22</posy>
               <width>151</width>
               <height>227</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem5Var]</texture>
             </control>
             <control type="image">
@@ -666,7 +666,7 @@
               <posy>248</posy>
               <width>151</width>
               <height>226</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem5Var]</texture>
             </control>
             <control type="image">
@@ -674,7 +674,7 @@
               <posy>0</posy>
               <width>203</width>
               <height>331</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -702,7 +702,7 @@
               <posy>26</posy>
               <width>173</width>
               <height>258</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem4Var]</texture>
             </control>
             <control type="image">
@@ -710,7 +710,7 @@
               <posy>284</posy>
               <width>173</width>
               <height>258</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem4Var]</texture>
             </control>
             <control type="image">
@@ -718,7 +718,7 @@
               <posy>0</posy>
               <width>232</width>
               <height>379</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -746,7 +746,7 @@
               <posy>29</posy>
               <width>195</width>
               <height>292</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem3Var]</texture>
             </control>
             <control type="image">
@@ -754,7 +754,7 @@
               <posy>320</posy>
               <width>195</width>
               <height>292</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem3Var]</texture>
             </control>
             <control type="image">
@@ -762,7 +762,7 @@
               <posy>0</posy>
               <width>262</width>
               <height>427</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -790,7 +790,7 @@
               <posy>32</posy>
               <width>217</width>
               <height>325</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem2Var]</texture>
             </control>
             <control type="image">
@@ -798,7 +798,7 @@
               <posy>356</posy>
               <width>217</width>
               <height>325</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem2Var]</texture>
             </control>
             <control type="image">
@@ -806,7 +806,7 @@
               <posy>0</posy>
               <width>291</width>
               <height>475</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -834,7 +834,7 @@
               <posy>35</posy>
               <width>239</width>
               <height>358</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem1Var]</texture>
             </control>
             <control type="image">
@@ -842,7 +842,7 @@
               <posy>392</posy>
               <width>239</width>
               <height>358</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem1Var]</texture>
             </control>
             <control type="image">
@@ -850,7 +850,7 @@
               <posy>0</posy>
               <width>321</width>
               <height>523</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -878,7 +878,7 @@
               <posy>38</posy>
               <width>261</width>
               <height>391</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem0Var]</texture>
             </control>
             <control type="image">
@@ -886,7 +886,7 @@
               <posy>428</posy>
               <width>261</width>
               <height>391</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem0Var]</texture>
             </control>
             <control type="image">
@@ -920,7 +920,7 @@
               <posy>0</posy>
               <width>350</width>
               <height>571</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay-focus.png</texture>
             </control>
           </control>
@@ -943,7 +943,7 @@
               <posy>0</posy>
               <width>350</width>
               <height>571</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
           </control>
@@ -966,7 +966,7 @@
               <posy>0</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem-1Var]</texture>
             </control>
             <control type="image">
@@ -974,7 +974,7 @@
               <posy>424</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem-1Var]</texture>
             </control>
             <control type="image">
@@ -982,7 +982,7 @@
               <posy>416</posy>
               <width>323</width>
               <height>40</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay-focus.png</texture>
             </control>
             <control type="image">
@@ -1027,7 +1027,7 @@
               <posy>16</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem8Var]</texture>
             </control>
             <control type="image">
@@ -1035,7 +1035,7 @@
               <posy>176</posy>
               <width>107</width>
               <height>161</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem8Var]</texture>
             </control>
             <control type="image">
@@ -1043,7 +1043,7 @@
               <posy>0</posy>
               <width>144</width>
               <height>235</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1084,7 +1084,7 @@
               <posy>19</posy>
               <width>129</width>
               <height>194</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem7Var]</texture>
             </control>
             <control type="image">
@@ -1092,7 +1092,7 @@
               <posy>212</posy>
               <width>129</width>
               <height>193</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem7Var]</texture>
             </control>
             <control type="image">
@@ -1100,7 +1100,7 @@
               <posy>0</posy>
               <width>173</width>
               <height>283</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1141,7 +1141,7 @@
               <posy>22</posy>
               <width>151</width>
               <height>227</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem6Var]</texture>
             </control>
             <control type="image">
@@ -1149,7 +1149,7 @@
               <posy>248</posy>
               <width>151</width>
               <height>226</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem6Var]</texture>
             </control>
             <control type="image">
@@ -1157,7 +1157,7 @@
               <posy>0</posy>
               <width>203</width>
               <height>331</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1198,7 +1198,7 @@
               <posy>26</posy>
               <width>173</width>
               <height>258</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem5Var]</texture>
             </control>
             <control type="image">
@@ -1206,7 +1206,7 @@
               <posy>284</posy>
               <width>173</width>
               <height>258</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem5Var]</texture>
             </control>
             <control type="image">
@@ -1214,7 +1214,7 @@
               <posy>0</posy>
               <width>232</width>
               <height>379</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1255,7 +1255,7 @@
               <posy>29</posy>
               <width>195</width>
               <height>292</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem4Var]</texture>
             </control>
             <control type="image">
@@ -1263,7 +1263,7 @@
               <posy>320</posy>
               <width>195</width>
               <height>292</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem4Var]</texture>
             </control>
             <control type="image">
@@ -1271,7 +1271,7 @@
               <posy>0</posy>
               <width>262</width>
               <height>427</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1312,7 +1312,7 @@
               <posy>32</posy>
               <width>217</width>
               <height>325</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem3Var]</texture>
             </control>
             <control type="image">
@@ -1320,7 +1320,7 @@
               <posy>356</posy>
               <width>217</width>
               <height>325</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem3Var]</texture>
             </control>
             <control type="image">
@@ -1328,7 +1328,7 @@
               <posy>0</posy>
               <width>291</width>
               <height>475</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1369,7 +1369,7 @@
               <posy>35</posy>
               <width>239</width>
               <height>358</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem2Var]</texture>
             </control>
             <control type="image">
@@ -1377,7 +1377,7 @@
               <posy>392</posy>
               <width>239</width>
               <height>358</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem2Var]</texture>
             </control>
             <control type="image">
@@ -1385,7 +1385,7 @@
               <posy>0</posy>
               <width>321</width>
               <height>523</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1426,7 +1426,7 @@
               <posy>38</posy>
               <width>261</width>
               <height>391</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem1Var]</texture>
             </control>
             <control type="image">
@@ -1434,7 +1434,7 @@
               <posy>428</posy>
               <width>261</width>
               <height>391</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem1Var]</texture>
             </control>
             <control type="image">
@@ -1442,7 +1442,7 @@
               <posy>0</posy>
               <width>350</width>
               <height>571</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay.png</texture>
             </control>
             <control type="image">
@@ -1483,7 +1483,7 @@
               <posy>41</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" diffuse="thumbs/posterdiffuse.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem0Var]</texture>
             </control>
             <control type="image">
@@ -1491,7 +1491,7 @@
               <posy>465</posy>
               <width>284</width>
               <height>424</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="true" flipy="true" diffuse="thumbs/posterreflectiondiffuse2.png" fallback="DefaultVideoBigPoster.png">$VAR[ShowcaseItem0Var]</texture>
             </control>
             <control type="image">
@@ -1499,7 +1499,7 @@
               <posy>0</posy>
               <width>380</width>
               <height>620</height>
-              <aspectratio scalediffuse="false">scale</aspectratio>
+              <aspectratio scalediffuse="false">stretch</aspectratio>
               <texture background="false">thumbs/poster_overlay-focus.png</texture>
             </control>
             <control type="image">


### PR DESCRIPTION
By changing yesterday all the <aspectratio> from "stretchdiffuse="false">stretch" to "scalediffuse="false">scale", the Posters viewtype looked OK when the screen resolution was exactly 16:9 (e.g 1280x720), but had problems in other resolutions. For example, my 1280x800 screen: http://img6.imageshack.us/img6/2452/screenshot000s.png
