### PR TITLE
Some small fixes for the french translation

### DIFF
--- a/language/French/strings.xml
+++ b/language/French/strings.xml
@@ -39,9 +39,9 @@
   <string id="31052">Restant</string>
   <string id="31053">Plein écran</string>
   <string id="31054">Saison Fanart</string>
-  <string id="31055">Ouvrir la playlist</string>
-  <string id="31056">Sauvegarder la playlist</string>
-  <string id="31057">Fermer la playlist</string>
+  <string id="31055">Ouvrir la playliste</string>
+  <string id="31056">Sauvegarder la playliste</string>
+  <string id="31057">Fermer la playliste</string>
   <string id="31058">Bannière</string>
   <string id="31059">Logo</string>
   <string id="31060">Poster</string>
@@ -186,7 +186,7 @@
   <string id="31322">Diffusé</string>
   <string id="31323">Derniers films</string>
   <string id="31324">Derniers épisodes</string>
-  <string id="31325">Options de playlist</string>
+  <string id="31325">Options de la playliste</string>
   <string id="31326">Albums les plus écoutés</string>
   <string id="31328">Récemment ajouté</string>
   <string id="31331">Dernier film</string>
@@ -260,7 +260,7 @@
   <string id="31477">Tri panneau</string>
   <string id="31478">Configuration</string>
   <string id="31479">Widgets</string>
-  <string id="31480">Playlist personnalisée</string>
+  <string id="31480">Playliste personnalisée</string>
   <string id="31481">Afficher la bannière au lieu du logo</string>
   <string id="31482">Boitiers</string>
   <string id="31483">Montrer l'étiquette icône</string>
@@ -304,7 +304,7 @@
   <string id="31642">'PDA Météo'</string>
   <string id="31643">Personnaliser les éléments de la fenêtre d'accueil</string>
   <string id="31646">Voulez-vous télécharger toutes les images [CR]disponibles sans intervention de l'utilisateur ?</string>
-  <string id="31672">Inclure les éléments déja vus dans la playlist</string>
+  <string id="31672">Inclure les éléments déja vus dans la playliste</string>
   <string id="31674">Changer la disposition de l'affichage</string>
   <string id="31675">Personnaliser la barre supérieure</string>
   <string id="31676">Barre supérieure</string>
@@ -353,8 +353,8 @@
   <string id="41146">Add-on Musical</string>
   <string id="41147">Add-on Image</string>
   <string id="41148">Add-on Programme</string>
-  <string id="41149">Playlist vidéo</string>
-  <string id="41150">Playlist musicale</string>
+  <string id="41149">Playliste vidéo</string>
+  <string id="41150">Playliste musicale</string>
   <string id="41151">Personnalisé</string>
   <string id="41153">Favori</string>
   <string id="41154">Fonction</string>
@@ -386,7 +386,7 @@
   <string id="42101">Définir la couleur de la fenêtre 'Paramètres'</string>
   <string id="42102">VENTILER AUJOURD'HUI</string>
   <string id="42104">Disque par défaut cdART</string>
-  <string id="42105">Widget playlist</string>
+  <string id="42105">Widget playliste</string>
   <string id="51506">Groupes disponibles</string>
   <string id="51510">Réglage de la minuterie</string>
   <string id="52000">Chaîne +</string>


### PR DESCRIPTION
Hi,

I just fixed a few typos, but this is mostly untested as I know next to nothing about xbmc programming and I didn't see most of the string show up in any screen... (you might just as well ignore this if you find it risky).

Two side notes : 
- Some words do not exist in french (like playliste which should be "liste de lecture" or simply "playlist") but for consistency I didn't touch them because they are already used in the main xbmc translation.
- The accented caps are badly displayed in the setting screens (don't know why, maybe because of the font ?) : these letter have a lower baseline than the others which doesn't fit well in the skin which is very neat...

Your skin is outstanding, keep up the great work !

cheers,
David
