### PR TITLE
Selected color for title in pause (TV Shows)

### DIFF
--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -811,7 +811,7 @@
                             <align>center</align>
                             <aligny>center</aligny>
                             <font>Font_Condensed22</font>
-                            <textcolor>grey</textcolor>
+                            <textcolor>$VAR[SubTitleColorVar]</textcolor>
                             <scroll>true</scroll>
                             <label>$INFO[VideoPlayer.TVShowTitle]</label>
                             <visible>VideoPlayer.Content(episodes)</visible>


### PR DESCRIPTION
I missed this one in my last commit. The TV show title under the episode name in the pause screen should abide to the selected color scheme.
