### PR TITLE
MusicOverlay.xml: unbalanced parenthesis in onload condition

### DIFF
--- a/1080i/MusicOverlay.xml
+++ b/1080i/MusicOverlay.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <window id="2004">
-    <onload condition="system.hasaddon(script.artistslideshow) + IsEmpty(Window(Home).Property(ArtistSlideShowLoaded)">RunScript(script.artistslideshow, daemon=True)</onload>
+    <onload condition="system.hasaddon(script.artistslideshow) + IsEmpty(Window(Home).Property(ArtistSlideShowLoaded))">RunScript(script.artistslideshow, daemon=True)</onload>
     <onload>Skin.Reset(rotationtimer)</onload>
     <onload>AlarmClock(similarartistsmove,Control.Move(5222,1),00:04,silent,loop)</onload>
     <onload>AlarmClock(NowPlaying,Skin.ToggleSetting(rotationtimer),00:15,silent,loop)</onload>


### PR DESCRIPTION
Just noticed an this in an error log today.
