### PR TITLE
added: epg start/end time before/after progress bar within channel osd

### DIFF
--- a/1080i/DialogPVRChannelsOSD.xml
+++ b/1080i/DialogPVRChannelsOSD.xml
@@ -80,10 +80,10 @@
                 <viewtype label="535">list</viewtype>
                 <pagecontrol>60</pagecontrol>
                 <scrolltime>200</scrolltime>
-                <itemlayout height="98" width="750">
+                <itemlayout height="113" width="750">
                     <control type="image">
                         <posx>26</posx>
-                        <posy>38</posy>
+                        <posy>53</posy>
                         <width>600</width>
                         <height>60</height>
                         <texture>PVR/SeparatorChannels.png</texture>
@@ -108,7 +108,7 @@
                     </control>
                     <control type="label">
                         <posx>45</posx>
-                        <posy>18</posy>
+                        <posy>32</posy>
                         <width>60</width>
                         <height>45</height>
                         <font>Font_Bold20_Caps</font>
@@ -140,11 +140,22 @@
                         <label>$INFO[ListItem.Title]</label>
                         <scroll>yes</scroll>
                     </control>
+                    <control type="label">
+		                <posx>195</posx>
+		                <posy>80</posy>
+		                <width>80</width>
+		                <height>20</height>
+		                <font>Font_Reg12</font>
+		                <aligny>center</aligny>
+		                <include>subcolornofocus</include>
+		                <label>$INFO[ListItem.StartTime]</label>
+		                <visible>ListItem.HasEpg</visible>
+		            </control>
                     <control type="progress" id="20">
                         <description>Progressbar</description>
-                        <posx>195</posx>
-                        <posy>80</posy>
-                        <width>345</width>
+                        <posx>265</posx>
+                        <posy>90</posy>
+                        <width>275</width>
                         <height>9</height>
                         <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
                         <texturebg border="12,0,12,0">dialogs/progress/progress_back.png</texturebg>
@@ -153,23 +164,34 @@
                         <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
                         <info>ListItem.Progress</info>
                     </control>
+                    <control type="label">
+		                <posx>550</posx>
+		                <posy>80</posy>
+		                <width>80</width>
+		                <height>20</height>
+		                <font>Font_Reg12</font>
+		                <aligny>center</aligny>
+		                <include>subcolornofocus</include>
+		                <label>$INFO[ListItem.EndTime]</label>
+		                <visible>ListItem.HasEpg</visible>
+		            </control>
                     <control type="image">
                         <description>Icon</description>
                         <posx>82</posx>
-                        <posy>1</posy>
+                        <posy>10</posy>
                         <width>90</width>
                         <height>90</height>
-                        <bordersize>8</bordersize>
+                        <bordersize>4</bordersize>
                         <texture background="true" fallback="DefaultVideo.png">$INFO[ListItem.Icon]</texture>
                         <aspectratio>keep</aspectratio>
                     </control>
                 </itemlayout>
-                <focusedlayout height="98" width="635">
+                <focusedlayout height="113" width="635">
                     <control type="image">
                         <posx>12</posx>
                         <posy>1</posy>
                         <width>635</width>
-                        <height>93</height>
+                        <height>113</height>
                         <texture>views/tripanel/listselect_fo.png</texture>
                         <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
                         <include>VisibleFadeEffect</include>
@@ -194,7 +216,7 @@
                     </control>
                     <control type="label">
                         <posx>45</posx>
-                        <posy>18</posy>
+                        <posy>32</posy>
                         <width>60</width>
                         <height>45</height>
                         <font>Font_Bold20_Caps</font>
@@ -218,16 +240,27 @@
                     </control>
                     <control type="image">
                         <posx>26</posx>
-                        <posy>38</posy>
+                        <posy>53</posy>
                         <width>600</width>
                         <height>60</height>
                         <texture>PVR/SeparatorChannels.png</texture>
                     </control>
+                    <control type="label">
+		                <posx>195</posx>
+		                <posy>80</posy>
+		                <width>80</width>
+		                <height>20</height>
+		                <font>Font_Reg12</font>
+		                <aligny>center</aligny>
+		                <include>subcolornofocus</include>
+		                <label>$INFO[ListItem.StartTime]</label>
+		                <visible>ListItem.HasEpg</visible>
+		            </control>
                     <control type="progress" id="20">
                         <description>Progressbar</description>
-                        <posx>195</posx>
-                        <posy>80</posy>
-                        <width>345</width>
+                        <posx>265</posx>
+                        <posy>90</posy>
+                        <width>275</width>
                         <height>9</height>
                         <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
                         <texturebg border="12,0,12,0">dialogs/progress/progress_back.png</texturebg>
@@ -236,13 +269,24 @@
                         <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
                         <info>ListItem.Progress</info>
                     </control>
+                    <control type="label">
+		                <posx>550</posx>
+		                <posy>80</posy>
+		                <width>80</width>
+		                <height>20</height>
+		                <font>Font_Reg12</font>
+		                <aligny>center</aligny>
+		                <include>subcolornofocus</include>
+		                <label>$INFO[ListItem.EndTime]</label>
+		                <visible>ListItem.HasEpg</visible>
+		            </control>
                     <control type="image">
                         <description>Icon</description>
                         <posx>82</posx>
-                        <posy>1</posy>
+                        <posy>10</posy>
                         <width>90</width>
                         <height>90</height>
-                        <bordersize>8</bordersize>
+                        <bordersize>4</bordersize>
                         <texture background="true" fallback="DefaultVideo.png">$INFO[ListItem.Icon]</texture>
                         <aspectratio>keep</aspectratio>
                     </control>


### PR DESCRIPTION
I added epg start/end time before/after the progress bar within the channel osd to improve the usability.
