### PR TITLE
pvr: improved live tv layout 

### DIFF
--- a/1080i/Includes_PVR.xml
+++ b/1080i/Includes_PVR.xml
@@ -4,7 +4,6 @@
         <control type="group">
             <control type="list" id="11">
                 <description>TV Channels group</description>
-                <visible>Control.IsVisible(11)</visible>
                 <include>VisibleFadeEffect</include>
                 <onup>11</onup>
                 <ondown>11</ondown>
@@ -96,7 +95,7 @@
                 <posy>64</posy>
                 <width>120</width>
                 <height>40</height>
-                <font>Font_Reg18</font>
+                <font>Font_Reg14</font>
                 <aligny>center</aligny>
                 <include>subcolornofocus</include>
                 <label>$INFO[ListItem.StartTime]</label>
@@ -104,7 +103,7 @@
             </control>
             <control type="progress">
                 <description>Progressbar</description>
-                <posx>290</posx>
+                <posx>270</posx>
                 <posy>80</posy>
                 <width>450</width>
                 <height>12</height>
@@ -121,7 +120,7 @@
                 <posy>64</posy>
                 <width>120</width>
                 <height>40</height>
-                <font>Font_Reg18</font>
+                <font>Font_Reg14</font>
                 <aligny>center</aligny>
                 <include>subcolornofocus</include>
                 <label>$INFO[ListItem.EndTime]</label>
@@ -200,7 +199,7 @@
                 <posy>64</posy>
                 <width>120</width>
                 <height>40</height>
-                <font>Font_Reg18</font>
+                <font>Font_Reg14</font>
                 <aligny>center</aligny>
                 <include>subcolorfocus</include>
                 <label>$INFO[ListItem.StartTime]</label>
@@ -208,7 +207,7 @@
             </control>
             <control type="progress">
                 <description>Progressbar</description>
-                <posx>290</posx>
+                <posx>270</posx>
                 <posy>80</posy>
                 <width>450</width>
                 <height>12</height>
@@ -225,7 +224,7 @@
                 <posy>64</posy>
                 <width>120</width>
                 <height>40</height>
-                <font>Font_Reg18</font>
+                <font>Font_Reg14</font>
                 <aligny>center</aligny>
                 <include>subcolorfocus</include>
                 <label>$INFO[ListItem.EndTime]</label>

--- a/1080i/MyPVR.xml
+++ b/1080i/MyPVR.xml
@@ -394,15 +394,6 @@
                     <include>Objects_MediaMenuButtonAlt</include>
                     <label>19023</label>
                 </control>
-                <control type="radiobutton" id="326">
-                    <description>small list</description>
-                    <posx>0</posx>
-                    <posy>188</posy>
-                    <onclick>Skin.ToggleSetting(smalltvlist)</onclick>
-                    <include>Objects_MediaMenuButtonAlt</include>
-                    <selected>!Skin.HasSetting(smalltvlist)</selected>
-                    <label>31175</label>
-                </control>
                 <control type="button" id="33">
                     <visible>!Skin.HasSetting(noradio)</visible>
                     <description>Radio Channels</description>
@@ -438,6 +429,15 @@
                     <posy>188</posy>
                     <include>Objects_MediaMenuButtonAlt</include>
                     <label>137</label>
+                </control>
+                <control type="radiobutton" id="326">
+                    <description>small list</description>
+                    <posx>0</posx>
+                    <posy>188</posy>
+                    <onclick>Skin.ToggleSetting(smalltvlist)</onclick>
+                    <include>Objects_MediaMenuButtonAlt</include>
+                    <selected>!Skin.HasSetting(smalltvlist)</selected>
+                    <label>31175</label>
                 </control>
                 <control type="button" id="1664">
                     <description>Set area color</description>


### PR DESCRIPTION
- fixed issue #320
- moved "big list" entry within the left sidebar down to the end
- change font size of channel items epg start/end time in large view to
  14
