### PR TITLE
Split options for "No"/"Delayed" infopanel

### DIFF
--- a/1080i/custom_1126_ViewtypeSettings.xml
+++ b/1080i/custom_1126_ViewtypeSettings.xml
@@ -177,7 +177,7 @@
                 <alttexturefocus>views/tripanel/listselect_fo.png</alttexturefocus>
                 <textureradiofocus>common/arrowright.png</textureradiofocus>
                 <textureradionofocus></textureradionofocus>
-                <selected>Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv)</selected>
+                <selected>Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)</selected>
                 <textcolor>grey2</textcolor>
                 <focusedcolor>white6</focusedcolor>
                 <disabledcolor>grey3</disabledcolor>
@@ -191,26 +191,16 @@
                 <radioheight>30</radioheight>
                 <radioposx>542</radioposx>
                 <label>$LOCALIZE[31166]: [COLOR $VAR[FontColorVar]]$VAR[InfoPanelToggleLabelVar][/COLOR]</label>
-                <onright condition="![Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv)]">Dialog.Close(1126)</onright>
-                <onright condition="![Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv)]">SetFocus(50)</onright>
-                <onright condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv)">ActivateWindow(1114)</onright>
-                
-                
-                
+                <onright condition="![Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv)] | Skin.HasSetting(infopaneofftv)">Dialog.Close(1126)</onright>
+                <onright condition="![Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv)] | Skin.HasSetting(infopaneofftv)">SetFocus(50)</onright>
+                <onright condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)">ActivateWindow(1114)</onright>
                 <onclick condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + Skin.HasSetting(infopaneofftv)">Skin.Reset(showcaseinfoontv)</onclick>
                 <onclick condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + Skin.HasSetting(infopaneofftv)">Skin.Reset(infopaneautotv)</onclick>
                 <onclick condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + Skin.HasSetting(infopaneofftv)">Skin.Reset(infopaneofftv)</onclick>
-                
-                
                 <onclick condition="!Skin.HasSetting(showcaseinfoontv) + !Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)">Skin.SetBool(showcaseinfoontv)</onclick>
-                
-                
                 <onclick condition="Skin.HasSetting(showcaseinfoontv) + !Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)">Notification($LOCALIZE[42002],$LOCALIZE[42001])</onclick>
                 <onclick condition="Skin.HasSetting(showcaseinfoontv) + !Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)">Skin.SetBool(infopaneautotv)</onclick>
-                
-                                <onclick condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)">Skin.SetBool(infopaneofftv)</onclick>
-
-                
+                <onclick condition="Skin.HasSetting(showcaseinfoontv) + Skin.HasSetting(infopaneautotv) + !Skin.HasSetting(infopaneofftv)">Skin.SetBool(infopaneofftv)</onclick>
                 <visible>[Container.Content(tvshows) | Container.Content(seasons)] + !stringcompare(Skin.String(actualViewtype),bigfan)</visible>
                 <visible>stringcompare(Skin.String(actualViewtype),showcasemovies) | Stringcompare(Skin.String(actualViewtype),showcasedvd) | Stringcompare(Skin.String(actualViewtype),landscape) | Stringcompare(Skin.String(actualViewtype),showcasesquare) | Stringcompare(Skin.String(actualViewtype),banners)</visible>
             </control>
@@ -225,7 +215,7 @@
                 <alttexturefocus>views/tripanel/listselect_fo.png</alttexturefocus>
                 <textureradiofocus>common/arrowright.png</textureradiofocus>
                 <textureradionofocus></textureradionofocus>
-                <selected>Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto)</selected>
+                <selected>Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto) + !Skin.HasSetting(infopaneoff)</selected>
                 <textcolor>grey2</textcolor>
                 <focusedcolor>white6</focusedcolor>
                 <disabledcolor>grey3</disabledcolor>
@@ -239,34 +229,16 @@
                 <radioheight>30</radioheight>
                 <radioposx>542</radioposx>
                 <label>$LOCALIZE[31166]: [COLOR $VAR[FontColorVar]]$VAR[InfoPanelToggleLabelVar][/COLOR]</label>
-                <onright condition="![Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto)]">Dialog.Close(1126)</onright>
-                <onright condition="![Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto)]">SetFocus(50)</onright>
-                <onright condition="Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto)">ActivateWindow(1114)</onright>
-              
-
-
-
-
-
-              
+                <onright condition="![Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto)] | Skin.HasSetting(infopaneoff)">Dialog.Close(1126)</onright>
+                <onright condition="![Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto)] | Skin.HasSetting(infopaneoff)">SetFocus(50)</onright>
+                <onright condition="Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto) + !Skin.HasSetting(infopaneoff)">ActivateWindow(1114)</onright>
                 <onclick condition="Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto) + Skin.HasSetting(infopaneoff)">Skin.Reset(showcaseinfoon)</onclick>
                 <onclick condition="Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto) + Skin.HasSetting(infopaneoff)">Skin.Reset(infopaneauto)</onclick>
                 <onclick condition="Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto) + Skin.HasSetting(infopaneoff)">Skin.Reset(infopaneoff)</onclick>
-                
                 <onclick condition="!Skin.HasSetting(showcaseinfoon) + !Skin.HasSetting(infopaneauto) + !Skin.HasSetting(infopaneoff)">Skin.SetBool(showcaseinfoon)</onclick>
-                
                 <onclick condition="Skin.HasSetting(showcaseinfoon) + !Skin.HasSetting(infopaneauto) + !Skin.HasSetting(infopaneoff)">Notification($LOCALIZE[42002],$LOCALIZE[42001])</onclick>
                 <onclick condition="Skin.HasSetting(showcaseinfoon) + !Skin.HasSetting(infopaneauto) + !Skin.HasSetting(infopaneoff)">Skin.SetBool(infopaneauto)</onclick>
-                
-                
                 <onclick condition="Skin.HasSetting(showcaseinfoon) + Skin.HasSetting(infopaneauto) + !Skin.HasSetting(infopaneoff)">Skin.SetBool(infopaneoff)</onclick>
-
-                
-                
-                
-                
-                
-                
                 <visible>stringcompare(Skin.String(actualViewtype),showcasemovies) | Stringcompare(Skin.String(actualViewtype),showcasedvd) | Stringcompare(Skin.String(actualViewtype),landscape) | Stringcompare(Skin.String(actualViewtype),showcasesquare)</visible>
                 <visible>[Container.Content(movies) | Container.Content(musicvideos)] + !stringcompare(Skin.String(actualViewtype),bigfan)</visible>
             </control>


### PR DESCRIPTION
Pressing right for "No infopanel" on Landscape, DVD case, etc., does not change the delay anymore.
