### PR TITLE
pvr: using include 'FullScreenInfoBar' instead of simple progress bar

### DIFF
--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -961,7 +961,11 @@
             </control>
         </control>
         <control type="group">
-            <visible>!Window.IsActive(fullscreeninfo)</visible>
+            <visible>!Window.IsActive(fullscreeninfo) + VideoPlayer.Content(LiveTV)</visible>
+            <include>FullScreenInfoBar</include>
+        </control>
+        <control type="group">
+            <visible>!Window.IsActive(fullscreeninfo) + !VideoPlayer.Content(LiveTV)</visible>
             <posy>993</posy>
             <animation type="Visible">
                 <effect type="fade" time="200" start="0" end="100" />

--- a/1080i/includes.xml
+++ b/1080i/includes.xml
@@ -1190,430 +1190,430 @@
         </item>
     </include>
     <include name="FileManagerPanels">
-            <control type="image">
-                <posx>105</posx>
-                <posy>110</posy>
-                <width>748</width>
-                <height>683</height>
-                <texture>wall/wall_bg_glow.png</texture>
-                <visible>!Skin.HasSetting(DisableGlowbar)</visible>
-                <include>PanelGlowFade</include>
-                <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
-            </control>
-            <control type="image">
-                <posx>105</posx>
-                <posy>110</posy>
-                <width>748</width>
-                <height>683</height>
-                    <texture>wall/wall_bg.png</texture>
-            </control>
-            <control type="image">
-                <posx>105</posx>
-                <posy>112</posy>
-                <width>748</width>
-                <height>683</height>
-                <texture>wall/wall_bg_reflection.png</texture>
-            </control>
-            <control type="image">
-                <posx>675</posx>
-                <posy>149</posy>
-                <width>128</width>
-                <height>540</height>
-                <texture>views/listpanel_detailwide.png</texture>
-                <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
-            </control>
+        <control type="image">
+            <posx>105</posx>
+            <posy>110</posy>
+            <width>748</width>
+            <height>683</height>
+            <texture>wall/wall_bg_glow.png</texture>
+            <visible>!Skin.HasSetting(DisableGlowbar)</visible>
+            <include>PanelGlowFade</include>
+            <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
+        </control>
+        <control type="image">
+            <posx>105</posx>
+            <posy>110</posy>
+            <width>748</width>
+            <height>683</height>
+            <texture>wall/wall_bg.png</texture>
+        </control>
+        <control type="image">
+            <posx>105</posx>
+            <posy>112</posy>
+            <width>748</width>
+            <height>683</height>
+            <texture>wall/wall_bg_reflection.png</texture>
+        </control>
+        <control type="image">
+            <posx>675</posx>
+            <posy>149</posy>
+            <width>128</width>
+            <height>540</height>
+            <texture>views/listpanel_detailwide.png</texture>
+            <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
+        </control>
     </include>
-                <include name="FileBrowserPanel">
+    <include name="FileBrowserPanel">
+        <control type="image">
+            <posx>92</posx>
+            <posy>110</posy>
+            <width>1132</width>
+            <height>1056</height>
+            <texture>wall/wall_bg_glow.png</texture>
+            <visible>!Skin.HasSetting(DisableGlowbar)</visible>
+            <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
+            <include>Animation_VisibleChange400</include>
+            <include>PanelGlowFade</include>
+        </control>
+        <control type="image">
+            <posx>92</posx>
+            <posy>110</posy>
+            <width>1132</width>
+            <height>1056</height>
+            <texture>wall/wall_bg.png</texture>
+            <icolordiffuse>$VAR[DialogColorVar]</icolordiffuse>
+        </control>
+    </include>
+    <include name="FullScreenInfoBar">
+        <control type="image">
+            <posx>704</posx>
+            <posy>866</posy>
+            <width>513</width>
+            <height>87</height>
+            <texture>osd/osd_bottom_bar.png</texture>
+            <visible>player.chaptercount + ![Player.Forwarding | Player.Rewinding]</visible>
+        </control>
+        <control type="label" id="1">
+            <posx>750</posx>
+            <posy>910</posy>
+            <width>420</width>
+            <height>42</height>
+            <aligny>center</aligny>
+            <align>center</align>
+            <font>Font_Reg19_Caps</font>
+            <textcolor>FF363636</textcolor>
+            <shadowcolor>88e5e5e5</shadowcolor>
+            <label>[UPPERCASE]$LOCALIZE[21396]: $INFO[player.chapter]$INFO[player.chaptercount, / ][/UPPERCASE]</label>
+            <visible>player.chaptercount + ![Player.Forwarding | Player.Rewinding]</visible>
+        </control>
+        <control type="image">
+            <posx>0</posx>
+            <posy>945</posy>
+            <width>1920</width>
+            <height>135</height>
+            <texture>osd/osd_back.png</texture>
+        </control>
+        <control type="group">
+            <posy>789</posy>
+            <visible>VideoPlayer.Content(episodes) | VideoPlayer.Content(movies)</visible>
+            <control type="image" id="1000">
+                <posx>22</posx>
+                <posy>-51</posy>
+                <width>345</width>
+                <height>234</height>
+                <texture background="true" fallback="empty.png">$INFO[Player.FolderPath,,/clearart.png]</texture>
+                <aspectratio>keep</aspectratio>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="0" end="100" time="600" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
+            </control>
+            <control type="image" id="1001">
+                <posx>22</posx>
+                <posy>-51</posy>
+                <width>345</width>
+                <height>234</height>
+                <texture background="true" fallback="empty.png">$INFO[Player.FolderPath,,/../clearart.png]</texture>
+                <aspectratio>keep</aspectratio>
+                <visible>StringCompare(Control.GetLabel(1000),empty.png)</visible>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="0" end="100" time="600" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
+            </control>
+            <control type="image" id="1002">
+                <posx>22</posx>
+                <posy>-66</posy>
+                <width>345</width>
+                <height>234</height>
+                <texture background="true" fallback="empty.png">$INFO[Player.FolderPath,,/logo.png]</texture>
+                <aspectratio>keep</aspectratio>
+                <visible>StringCompare(Control.GetLabel(1000),empty.png) + StringCompare(Control.GetLabel(1001),empty.png)</visible>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="0" end="100" time="600" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
+            </control>
+            <control type="image" id="1003">
+                <posx>22</posx>
+                <posy>-66</posy>
+                <width>345</width>
+                <height>234</height>
+                <visible>StringCompare(Control.GetLabel(1000),empty.png) + StringCompare(Control.GetLabel(1001),empty.png) + StringCompare(Control.GetLabel(1002),empty.png)</visible>
+                <texture background="true">$INFO[Player.FolderPath,,/../logo.png]</texture>
+                <aspectratio>keep</aspectratio>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="0" end="100" time="600" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
+            </control>
+        </control>
+        <control type="group">
+            <posy>910</posy>
+            <include>Neon_Topbar</include>
+        </control>
+        <control type="image" id="888777">
+            <include>HiddenObject</include>
+            <texture>$INFO[VideoPlayer.Cover]</texture>
+            <visible>no</visible>
+        </control>
+        <control type="group">
+            <visible>!Skin.HasSetting(DisableVideoThumb) + !substring(Control.GetLabel(888777),defaultvideo)</visible>
+            <include>Animation_VisibleChange200</include>
+            <control type="group">
+                <visible>VideoPlayer.Content(movies) | VideoPlayer.Content(MusicVideos)</visible>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
                 <control type="image">
-                    <posx>92</posx>
-                    <posy>110</posy>
-                    <width>1132</width>
-                    <height>1056</height>
-                    <texture>wall/wall_bg_glow.png</texture>
+                    <posx>1562</posx>
+                    <posy>581</posy>
+                    <width>335</width>
+                    <height>504</height>
                     <visible>!Skin.HasSetting(DisableGlowbar)</visible>
+                    <texture>thumbs/thumb_glass_shadow.png</texture>
+                    <include>PanelGlowFade</include>
                     <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
                     <include>Animation_VisibleChange400</include>
-                    <include>PanelGlowFade</include>
                 </control>
                 <control type="image">
-                    <posx>92</posx>
+                    <posx>1575</posx>
+                    <posy>600</posy>
+                    <width>310</width>
+                    <height>465</height>
+                    <texture background="true" diffuse="thumbs/movieposter_mask.png">$INFO[VideoPlayer.Cover]</texture>
+                    <aspectratio aligny="bottom">stretch</aspectratio>
+                </control>
+                <control type="image">
+                    <posx>1555</posx>
+                    <posy>580</posy>
+                    <width>349</width>
+                    <height>504</height>
+                    <texture diffuse="thumbs/movieposter_mask.png">thumbs/thumb_glass_noreflect.png</texture>
+                    <bordertexture border="19.5">thumbs/poster_shadow.png</bordertexture>
+                    <bordersize>19</bordersize>
+                </control>
+            </control>
+            <control type="group">
+                <visible>VideoPlayer.Content(episodes) | VideoPlayer.Content(LiveTV)</visible>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
+                <control type="image">
+                    <texture>thumbs/multiplex_tvmask_shadow.png</texture>
+                    <posx>1528</posx>
+                    <posy>853</posy>
+                    <width>400</width>
+                    <height>225</height>
+                    <include>PanelGlowFade</include>
+                    <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
+                    <visible>!Skin.HasSetting(DisableGlowbar)</visible>
+                    <visible>!VideoPlayer.Content(LiveTV)</visible>
+                    <include>Animation_VisibleChange400</include>
+                </control>
+                <control type="image">
+                    <posx>1545</posx>
+                    <posy>862</posy>
+                    <width>368</width>
+                    <height>207</height>
+                    <texture background="true" diffuse="thumbs/multiplex_tvmask.png">$INFO[VideoPlayer.Cover]</texture>
+                    <aspectratio scalediffuse="false">scale</aspectratio>
+                    <visible>!VideoPlayer.Content(LiveTV)</visible>
+                </control>
+                <control type="image">
+                    <posx>1536</posx>
+                    <posy>853</posy>
+                    <width>386</width>
+                    <height>225</height>
+                    <texture background="true" diffuse="thumbs/multiplex_tvmask.png">thumbs/multiplex_tv_glass_reflect.png</texture>
+                    <aspectratio scalediffuse="false">scale</aspectratio>
+                    <bordertexture border="9">thumbs/multiplex_tvborder.png</bordertexture>
+                    <bordersize>9</bordersize>
+                    <visible>!VideoPlayer.Content(LiveTV)</visible>
+                </control>
+                <control type="image">
+                    <posx>1545</posx>
+                    <posy>862</posy>
+                    <width>368</width>
+                    <height>207</height>
+                    <texture>$INFO[VideoPlayer.Cover]</texture>
+                    <aspectratio>keep</aspectratio>
+                    <visible>VideoPlayer.Content(LiveTV) + !IsEmpty(VideoPlayer.Cover)</visible>
+                </control>
+                <control type="label">
+                    <posx>-255</posx>
+                    <posy>975</posy>
+                    <width>900</width>
+                    <height>68</height>
+                    <align>center</align>
+                    <aligny>center</aligny>
+                    <font>Font_ShowcaseMainLabel2_Caps</font>
+                    <textcolor>white2</textcolor>
+                    <label>[UPPERCASE][B]$INFO[VideoPlayer.ChannelName][/B][/UPPERCASE]</label>
+                    <scroll>true</scroll>
+                    <visible>VideoPlayer.Content(LiveTV)</visible>
+                </control>
+            </control>
+            <control type="group">
+                <visible>VideoPlayer.Content(files)</visible>
+                <animation type="WindowOpen">
+                    <effect type="slide" start="450,0" end="0,0" time="600" tween="cubic" easing="out" />
+                </animation>
+                <animation type="WindowClose">
+                    <effect type="slide" start="0,0" end="450,0" time="600" tween="cubic" easing="out" />
+                    <effect type="fade" start="100" end="0" time="600" />
+                </animation>
+                <control type="image">
+                    <posx>1568</posx>
+                    <posy>594</posy>
+                    <width>324</width>
+                    <height>479</height>
+                    <texture background="true">$INFO[VideoPlayer.Cover]</texture>
+                    <aspectratio aligny="bottom">keep</aspectratio>
+                    <bordertexture border="7">thumbs/thumbshadow.png</bordertexture>
+                    <bordersize>7</bordersize>
+                </control>
+            </control>
+        </control>
+        <control type="progress" id="23">
+            <posx>390</posx>
+            <posy>1002</posy>
+            <width>1140</width>
+            <height>22</height>
+            <info>Player.ProgressCache</info>
+            <texturebg>osd/info/osd_progress_back.png</texturebg>
+            <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
+            <lefttexture>osd/info/osd_progresscache_left.png</lefttexture>
+            <midtexture>osd/info/osd_progresscache_mid.png</midtexture>
+            <righttexture>osd/info/osd_progresscache_right.png</righttexture>
+            <overlaytexture>-</overlaytexture>
+            <visible>true</visible>
+        </control>
+        <control type="progress" id="23">
+            <posx>390</posx>
+            <posy>1002</posy>
+            <width>1140</width>
+            <height>22</height>
+            <info>Player.Progress</info>
+            <texturebg>osd/info/osd_progress_back_cache.png</texturebg>
+            <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
+            <lefttexture>osd/info/osd_progress_left.png</lefttexture>
+            <midtexture>osd/info/osd_progress_mid.png</midtexture>
+            <righttexture>osd/info/osd_progress_right.png</righttexture>
+            <overlaytexture>-</overlaytexture>
+            <visible>true</visible>
+        </control>
+        <control type="fadelabel">
+            <posx>390</posx>
+            <posy>956</posy>
+            <width>1140</width>
+            <height>8</height>
+            <align>center</align>
+            <font>Font_Reg19</font>
+            <textcolor>$VAR[TitleColorVar]</textcolor>
+            <label>$INFO[VideoPlayer.Director,[COLOR bcicon]$LOCALIZE[31156][/COLOR] ]</label>
+            <label>$INFO[VideoPlayer.Writer,[COLOR bcicon]$LOCALIZE[31157][/COLOR] ]</label>
+            <label>$INFO[VideoPlayer.Genre]</label>
+            <label>$INFO[VideoPlayer.RatingAndVotes,[COLOR bcicon]$LOCALIZE[31095]:[/COLOR] ]$INFO[VideoPlayer.Top250,[COLOR bcicon] $LOCALIZE[13409][/COLOR] # ]</label>
+            <label>$INFO[VideoPlayer.mpaa]</label>
+            <scroll>true</scroll>
+            <scrollout>false</scrollout>
+            <scrollspeed>70</scrollspeed>
+            <pauseatend>5000</pauseatend>
+            <visible>VideoPlayer.Content(movies)</visible>
+        </control>
+        <control type="fadelabel">
+            <posx>390</posx>
+            <posy>956</posy>
+            <width>1140</width>
+            <height>8</height>
+            <align>center</align>
+            <font>Font_Reg19</font>
+            <textcolor>white6</textcolor>
+            <label>$INFO[VideoPlayer.premiered,[COLOR bcicon]$LOCALIZE[20416]: [/COLOR]]</label>
+            <label>$INFO[VideoPlayer.PlayCount,[COLOR bcicon]$LOCALIZE[567]: [/COLOR]]</label>
+            <label>$INFO[VideoPlayer.LastPlayed,[COLOR bcicon]$LOCALIZE[568]: [/COLOR]]</label>
+            <scroll>true</scroll>
+            <scrollout>false</scrollout>
+            <scrollspeed>70</scrollspeed>
+            <pauseatend>5000</pauseatend>
+            <visible>VideoPlayer.Content(episodes)</visible>
+        </control>
+        <control type="group">
+            <posx>0</posx>
+            <posy>915</posy>
+            <control type="group">
+                <visible>VideoPlayer.Content(movies) | VideoPlayer.Content(MusicVideos) | VideoPlayer.Content(episodes)</visible>
+                <animation effect="slide" start="0,0" end="0,30" reversible="true" condition="IsEmpty(VideoPlayer.Rating)">Conditional</animation>
+                <control type="label">
+                    <posx>38</posx>
+                    <posy>56</posy>
+                    <width>300</width>
+                    <height>38</height>
+                    <align>center</align>
+                    <aligny>center</aligny>
+                    <font>Font_OSDTitle2</font>
+                    <label>$INFO[VideoPlayer.Year]$VAR[VideoSeasonVar,S]$VAR[VideoEpisodeVar,E]</label>
+                </control>
+                <control type="image">
+                    <posx>98</posx>
                     <posy>110</posy>
-                    <width>1132</width>
-                    <height>1056</height>
-                    <texture>wall/wall_bg.png</texture>
-                    <icolordiffuse>$VAR[DialogColorVar]</icolordiffuse>
-                </control>
-            </include>
-            <include name="FullScreenInfoBar">
-           <control type="image">
-                <posx>704</posx>
-                <posy>866</posy>
-                <width>513</width>
-                <height>87</height>
-                <texture>osd/osd_bottom_bar.png</texture>
-                <visible>player.chaptercount + ![Player.Forwarding | Player.Rewinding]</visible>
-            </control>
-            <control type="label" id="1">
-                <posx>750</posx>
-                <posy>910</posy>
-                <width>420</width>
-                <height>42</height>
-                <aligny>center</aligny>
-                <align>center</align>
-                <font>Font_Reg19_Caps</font>
-                <textcolor>FF363636</textcolor>
-                <shadowcolor>88e5e5e5</shadowcolor>
-                <label>[UPPERCASE]$LOCALIZE[21396]: $INFO[player.chapter]$INFO[player.chaptercount, / ][/UPPERCASE]</label>
-                <visible>player.chaptercount + ![Player.Forwarding | Player.Rewinding]</visible>
-            </control>
-            <control type="image">
-                <posx>0</posx>
-                <posy>945</posy>
-                <width>1920</width>
-                <height>135</height>
-                <texture>osd/osd_back.png</texture>
-            </control>
-              <control type="group">
-                    <posy>789</posy>
-                    <visible>VideoPlayer.Content(episodes) | VideoPlayer.Content(movies)</visible>
-                    <control type="image" id="1000">
-                        <posx>22</posx>
-                        <posy>-51</posy>
-                        <width>345</width>
-                        <height>234</height>
-                        <texture background="true" fallback="empty.png">$INFO[Player.FolderPath,,/clearart.png]</texture>
-                        <aspectratio>keep</aspectratio>
-                        <animation type="WindowOpen">
-                            <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="0" end="100" time="600" />
-                        </animation>
-                        <animation type="WindowClose">
-                            <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="100" end="0" time="600" />
-                        </animation>
-                    </control>
-                    <control type="image" id="1001">
-                        <posx>22</posx>
-                        <posy>-51</posy>
-                        <width>345</width>
-                        <height>234</height>
-                        <texture background="true" fallback="empty.png">$INFO[Player.FolderPath,,/../clearart.png]</texture>
-                        <aspectratio>keep</aspectratio>
-                        <visible>StringCompare(Control.GetLabel(1000),empty.png)</visible>
-                        <animation type="WindowOpen">
-                            <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="0" end="100" time="600" />
-                        </animation>
-                        <animation type="WindowClose">
-                            <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="100" end="0" time="600" />
-                        </animation>
-                    </control>
-                    <control type="image" id="1002">
-                        <posx>22</posx>
-                        <posy>-66</posy>
-                        <width>345</width>
-                        <height>234</height>
-                        <texture background="true" fallback="empty.png">$INFO[Player.FolderPath,,/logo.png]</texture>
-                        <aspectratio>keep</aspectratio>
-                        <visible>StringCompare(Control.GetLabel(1000),empty.png) + StringCompare(Control.GetLabel(1001),empty.png)</visible>
-                        <animation type="WindowOpen">
-                            <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="0" end="100" time="600" />
-                        </animation>
-                        <animation type="WindowClose">
-                            <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="100" end="0" time="600" />
-                        </animation>
-                    </control>
-                    <control type="image" id="1003">
-                        <posx>22</posx>
-                        <posy>-66</posy>
-                        <width>345</width>
-                        <height>234</height>
-                        <visible>StringCompare(Control.GetLabel(1000),empty.png) + StringCompare(Control.GetLabel(1001),empty.png) + StringCompare(Control.GetLabel(1002),empty.png)</visible>
-                        <texture background="true">$INFO[Player.FolderPath,,/../logo.png]</texture>
-                        <aspectratio>keep</aspectratio>
-                        <animation type="WindowOpen">
-                            <effect type="slide" start="-450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="0" end="100" time="600" />
-                        </animation>
-                        <animation type="WindowClose">
-                            <effect type="slide" start="0,0" end="-450,0" time="600" tween="cubic" easing="out" />
-                            <effect type="fade" start="100" end="0" time="600" />
-                        </animation>
-                    </control>
-                </control>
-            <control type="group">
-                <posy>910</posy>
-                <include>Neon_Topbar</include>
-            </control>
-            <control type="image" id="888777">
-                <include>HiddenObject</include>
-                <texture>$INFO[VideoPlayer.Cover]</texture>
-                <visible>no</visible>
-            </control>
-            <control type="group">
-                <visible>!Skin.HasSetting(DisableVideoThumb) + !substring(Control.GetLabel(888777),defaultvideo)</visible>
-                <include>Animation_VisibleChange200</include>
-                <control type="group">
-                    <visible>VideoPlayer.Content(movies) | VideoPlayer.Content(MusicVideos)</visible>
-                    <animation type="WindowOpen">
-                        <effect type="slide" start="450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                    </animation>
-                    <animation type="WindowClose">
-                        <effect type="slide" start="0,0" end="450,0" time="600" tween="cubic" easing="out" />
-                        <effect type="fade" start="100" end="0" time="600" />
-                    </animation>
-                    <control type="image">
-                        <posx>1562</posx>
-                        <posy>581</posy>
-                        <width>335</width>
-                        <height>504</height>
-                        <visible>!Skin.HasSetting(DisableGlowbar)</visible>
-                        <texture>thumbs/thumb_glass_shadow.png</texture>
-                        <include>PanelGlowFade</include>
-                        <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
-                        <include>Animation_VisibleChange400</include>
-                    </control>
-                    <control type="image">
-                        <posx>1575</posx>
-                        <posy>600</posy>
-                        <width>310</width>
-                        <height>465</height>
-                        <texture background="true" diffuse="thumbs/movieposter_mask.png">$INFO[VideoPlayer.Cover]</texture>
-                        <aspectratio aligny="bottom">stretch</aspectratio>
-                    </control>
-                    <control type="image">
-                        <posx>1555</posx>
-                        <posy>580</posy>
-                        <width>349</width>
-                        <height>504</height>
-                        <texture diffuse="thumbs/movieposter_mask.png">thumbs/thumb_glass_noreflect.png</texture>
-                        <bordertexture border="19.5">thumbs/poster_shadow.png</bordertexture>
-                        <bordersize>19</bordersize>
-                    </control>
-                </control>
-                <control type="group">
-                    <visible>VideoPlayer.Content(episodes) | VideoPlayer.Content(LiveTV)</visible>
-                    <animation type="WindowOpen">
-                        <effect type="slide" start="450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                    </animation>
-                    <animation type="WindowClose">
-                        <effect type="slide" start="0,0" end="450,0" time="600" tween="cubic" easing="out" />
-                        <effect type="fade" start="100" end="0" time="600" />
-                    </animation>
-                    <control type="image">
-                        <texture>thumbs/multiplex_tvmask_shadow.png</texture>
-                        <posx>1528</posx>
-                        <posy>853</posy>
-                        <width>400</width>
-                        <height>225</height>
-                        <include>PanelGlowFade</include>
-                        <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
-                        <visible>!Skin.HasSetting(DisableGlowbar)</visible>
-                        <visible>!VideoPlayer.Content(LiveTV)</visible>
-                        <include>Animation_VisibleChange400</include>
-                    </control>
-                    <control type="image">
-                        <posx>1545</posx>
-                        <posy>862</posy>
-                        <width>368</width>
-                        <height>207</height>
-                        <texture background="true" diffuse="thumbs/multiplex_tvmask.png">$INFO[VideoPlayer.Cover]</texture>
-                        <aspectratio scalediffuse="false">scale</aspectratio>
-                        <visible>!VideoPlayer.Content(LiveTV)</visible>
-                    </control>
-                    <control type="image">
-                        <posx>1536</posx>
-                        <posy>853</posy>
-                        <width>386</width>
-                        <height>225</height>
-                        <texture background="true" diffuse="thumbs/multiplex_tvmask.png">thumbs/multiplex_tv_glass_reflect.png</texture>
-                        <aspectratio scalediffuse="false">scale</aspectratio>
-                        <bordertexture border="9">thumbs/multiplex_tvborder.png</bordertexture>
-                        <bordersize>9</bordersize>
-                        <visible>!VideoPlayer.Content(LiveTV)</visible>
-                    </control>
-                    <control type="image">
-                        <posx>1545</posx>
-                        <posy>862</posy>
-                        <width>368</width>
-                        <height>207</height>
-                        <texture>$INFO[VideoPlayer.Cover]</texture>
-                        <aspectratio>keep</aspectratio>
-                        <visible>VideoPlayer.Content(LiveTV) + !IsEmpty(VideoPlayer.Cover)</visible>
-                    </control>
-                    <control type="label">
-                        <posx>-255</posx>
-                        <posy>975</posy>
-                        <width>900</width>
-                        <height>68</height>
-                        <align>center</align>
-                        <aligny>center</aligny>
-                        <font>Font_ShowcaseMainLabel2_Caps</font>
-                        <textcolor>white2</textcolor>
-                        <label>[UPPERCASE][B]$INFO[VideoPlayer.ChannelName][/B][/UPPERCASE]</label>
-                        <scroll>true</scroll>
-                        <visible>VideoPlayer.Content(LiveTV)</visible>
-                    </control>
-                </control>
-                <control type="group">
-                    <visible>VideoPlayer.Content(files)</visible>
-                    <animation type="WindowOpen">
-                        <effect type="slide" start="450,0" end="0,0" time="600" tween="cubic" easing="out" />
-                    </animation>
-                    <animation type="WindowClose">
-                        <effect type="slide" start="0,0" end="450,0" time="600" tween="cubic" easing="out" />
-                        <effect type="fade" start="100" end="0" time="600" />
-                    </animation>
-                    <control type="image">
-                        <posx>1568</posx>
-                        <posy>594</posy>
-                        <width>324</width>
-                        <height>479</height>
-                        <texture background="true">$INFO[VideoPlayer.Cover]</texture>
-                        <aspectratio aligny="bottom">keep</aspectratio>
-                        <bordertexture border="7">thumbs/thumbshadow.png</bordertexture>
-                        <bordersize>7</bordersize>
-                    </control>
+                    <width>180</width>
+                    <height>36</height>
+                    <colordiffuse>$VAR[TitleColorVar]</colordiffuse>
+                    <texture>$INFO[VideoPlayer.Rating,stars/,.png]</texture>
                 </control>
             </control>
-            <control type="progress" id="23">
+        </control>
+        <control type="group">
+            <posy>908</posy>
+            <control type="label">
                 <posx>390</posx>
-                <posy>1002</posy>
+                <posy>128</posy>
                 <width>1140</width>
-                <height>22</height>
-                <info>Player.ProgressCache</info>
-                <texturebg>osd/info/osd_progress_back.png</texturebg>
-                <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
-                <lefttexture>osd/info/osd_progresscache_left.png</lefttexture>
-                <midtexture>osd/info/osd_progresscache_mid.png</midtexture>
-                <righttexture>osd/info/osd_progresscache_right.png</righttexture>
-                <overlaytexture>-</overlaytexture>
-                <visible>true</visible>
-            </control>
-            <control type="progress" id="23">
-                <posx>390</posx>
-                <posy>1002</posy>
-                <width>1140</width>
-                <height>22</height>
-                <info>Player.Progress</info>
-                <texturebg>osd/info/osd_progress_back_cache.png</texturebg>
-                <colordiffuse>$VAR[ColorDiffuseVar]</colordiffuse>
-                <lefttexture>osd/info/osd_progress_left.png</lefttexture>
-                <midtexture>osd/info/osd_progress_mid.png</midtexture>
-                <righttexture>osd/info/osd_progress_right.png</righttexture>
-                <overlaytexture>-</overlaytexture>
-                <visible>true</visible>
-            </control>
-            <control type="fadelabel">
-                <posx>390</posx>
-                <posy>956</posy>
-                <width>1140</width>
-                <height>8</height>
-                <align>center</align>
-                <font>Font_Reg19</font>
-                <textcolor>$VAR[TitleColorVar]</textcolor>
-                <label>$INFO[VideoPlayer.Director,[COLOR bcicon]$LOCALIZE[31156][/COLOR] ]</label>
-                <label>$INFO[VideoPlayer.Writer,[COLOR bcicon]$LOCALIZE[31157][/COLOR] ]</label>
-                <label>$INFO[VideoPlayer.Genre]</label>
-                <label>$INFO[VideoPlayer.RatingAndVotes,[COLOR bcicon]$LOCALIZE[31095]:[/COLOR] ]$INFO[VideoPlayer.Top250,[COLOR bcicon] $LOCALIZE[13409][/COLOR] # ]</label>
-                <label>$INFO[VideoPlayer.mpaa]</label>
-                <scroll>true</scroll>
-                <scrollout>false</scrollout>
-                <scrollspeed>70</scrollspeed>
-                <pauseatend>5000</pauseatend>
-                <visible>VideoPlayer.Content(movies)</visible>
-            </control>
-            <control type="fadelabel">
-                <posx>390</posx>
-                <posy>956</posy>
-                <width>1140</width>
-                <height>8</height>
-                <align>center</align>
+                <height>38</height>
                 <font>Font_Reg19</font>
                 <textcolor>white6</textcolor>
-                <label>$INFO[VideoPlayer.premiered,[COLOR bcicon]$LOCALIZE[20416]: [/COLOR]]</label>
-                <label>$INFO[VideoPlayer.PlayCount,[COLOR bcicon]$LOCALIZE[567]: [/COLOR]]</label>
-                <label>$INFO[VideoPlayer.LastPlayed,[COLOR bcicon]$LOCALIZE[568]: [/COLOR]]</label>
-                <scroll>true</scroll>
-                <scrollout>false</scrollout>
-                <scrollspeed>70</scrollspeed>
-                <pauseatend>5000</pauseatend>
-                <visible>VideoPlayer.Content(episodes)</visible>
+                <label>$INFO[VideoPlayer.Time]</label>
             </control>
-            <control type="group">
+            <control type="label">
                 <posx>0</posx>
-                <posy>915</posy>
-                <control type="group">
-                    <visible>VideoPlayer.Content(movies) | VideoPlayer.Content(MusicVideos) | VideoPlayer.Content(episodes)</visible>
-                    <animation effect="slide" start="0,0" end="0,30" reversible="true" condition="IsEmpty(VideoPlayer.Rating)">Conditional</animation>
-                    <control type="label">
-                        <posx>38</posx>
-                        <posy>56</posy>
-                        <width>300</width>
-                        <height>38</height>
-                        <align>center</align>
-                        <aligny>center</aligny>
-                        <font>Font_OSDTitle2</font>
-                        <label>$INFO[VideoPlayer.Year]$VAR[VideoSeasonVar,S]$VAR[VideoEpisodeVar,E]</label>
-                    </control>
-                    <control type="image">
-                        <posx>98</posx>
-                        <posy>110</posy>
-                        <width>180</width>
-                        <height>36</height>
-                        <colordiffuse>$VAR[TitleColorVar]</colordiffuse>
-                        <texture>$INFO[VideoPlayer.Rating,stars/,.png]</texture>
-                    </control>
-                </control>
+                <posy>128</posy>
+                <width>1920</width>
+                <height>38</height>
+                <font>Font_Reg19</font>
+                <align>center</align>
+                <textcolor>white6</textcolor>
+                <label>$INFO[System.Time,, / ]$INFO[Player.FinishTime]</label>
             </control>
-            <control type="group">
-                <posy>908</posy>
-                <control type="label">
-                    <posx>390</posx>
-                    <posy>128</posy>
-                    <width>1140</width>
-                    <height>38</height>
-                    <font>Font_Reg19</font>
-                    <textcolor>white6</textcolor>
-                    <label>$INFO[VideoPlayer.Time]</label>
-                </control>
-                <control type="label">
-                    <posx>0</posx>
-                    <posy>128</posy>
-                    <width>1920</width>
-                    <height>38</height>
-                    <font>Font_Reg19</font>
-                    <align>center</align>
-                    <textcolor>white6</textcolor>
-                    <label>$INFO[System.Time,, / ]$INFO[Player.FinishTime]</label>
-                </control>
-                <control type="label">
-                    <posx>1530</posx>
-                    <posy>128</posy>
-                    <width>1140</width>
-                    <height>38</height>
-                    <font>Font_Reg19</font>
-                    <align>right</align>
-                    <textcolor>white6</textcolor>
-                    <label>$INFO[VideoPlayer.Duration]</label>
-                    <visible>!Skin.HasSetting(PreferRemaining)</visible>
-                </control>
-                <control type="label">
-                    <posx>1530</posx>
-                    <posy>128</posy>
-                    <width>1140</width>
-                    <height>38</height>
-                    <font>Font_Reg19</font>
-                    <align>right</align>
-                    <textcolor>white6</textcolor>
-                    <label>$INFO[Player.TimeRemaining,- ]</label>
-                    <visible>Skin.HasSetting(PreferRemaining)</visible>
-                </control>
+            <control type="label">
+                <posx>1530</posx>
+                <posy>128</posy>
+                <width>1140</width>
+                <height>38</height>
+                <font>Font_Reg19</font>
+                <align>right</align>
+                <textcolor>white6</textcolor>
+                <label>$INFO[VideoPlayer.Duration]</label>
+                <visible>!Skin.HasSetting(PreferRemaining)</visible>
             </control>
-            </include>
+            <control type="label">
+                <posx>1530</posx>
+                <posy>128</posy>
+                <width>1140</width>
+                <height>38</height>
+                <font>Font_Reg19</font>
+                <align>right</align>
+                <textcolor>white6</textcolor>
+                <label>$INFO[Player.TimeRemaining,- ]</label>
+                <visible>Skin.HasSetting(PreferRemaining)</visible>
+            </control>
+        </control>
+    </include>
     <include name="ClassicOSDButton">
         <posx>0</posx>
         <posy>0</posy>


### PR DESCRIPTION
Using fullscreeninfobar include within videos osd, because of displaying the channel-icon and channel-name.

Corrected the indentation in include.xml
