### PR TITLE
Make use of season-poster files if "use folder.jpg" is set, while viewin...

### DIFF
--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -1339,6 +1339,7 @@
         <value condition="Stringcompare(ListItem.label,..)">DefaultFolderBack.png</value>
         <value condition="Container.Content(genres)">$INFO[ListItem.Label,special://skin/extras/genre/video/icons/,.jpg]</value>
         <value condition="Skin.HasSetting(Nox.TVShowsUsePoster) + Container.Content(tvshows)">$INFO[ListItem.Path,,poster.jpg]</value>
+        <value condition="Skin.HasSetting(Nox.TVShowsUsePoster) + [SubString(Container.FolderPath,/-1/,right) | SubString(Container.FolderPath,/-2/,right) | SubString(Container.FolderPath,videodb://5/]">$INFO[ListItem.Path,,../season]$INFO[ListItem.Season,,-poster.jpg]</value>
         <value condition="!Control.IsVisible(50) + SubString(Container.FolderPath,videodb://5/)">$INFO[ListItem.Path,,../poster.jpg]</value>
         <value condition="!Control.IsVisible(50) + Container.Content(episodes) + !IsEmpty(Container.SeasonThumb)">$INFO[Container.SeasonThumb]</value>
         <value condition="!Control.IsVisible(50) + Container.Content(episodes) + IsEmpty(Container.SeasonThumb)">$INFO[Container.TvShowThumb]</value>


### PR DESCRIPTION
...g "\* All seasons", "RecentlyAddedEpisodes" or with "Flatten Always" [Tri-Panel]
