### PR TITLE
increase width of shutdown menu

### DIFF
--- a/1080i/DialogButtonMenu.xml
+++ b/1080i/DialogButtonMenu.xml
@@ -15,8 +15,8 @@
         <control type="group">
             <visible>!Skin.HasSetting(quicklistmenu)</visible>
             <control type="grouplist" id="800">
-                <posx>730</posx>
-                <width>460</width>
+                <posx>670</posx>
+                <width>550</width>
                 <height>1080</height>
                 <itemgap>0</itemgap>
                 <onleft>800</onleft>
@@ -27,7 +27,7 @@
                 <align>center</align>
                 <control type="image" id="18">
                     <posy>-39</posy>
-                    <width>460</width>
+                    <width>550</width>
                     <height>39</height>
                     <colordiffuse>$VAR[SpotColorVar2]</colordiffuse>
                     <texture>$VAR[ShutdownTopVar]</texture>
@@ -118,16 +118,16 @@
                 </control>
                 <control type="image" id="19">
                     <posy>699</posy>
-                    <width>460</width>
+                    <width>550</width>
                     <height>40</height>
                     <colordiffuse>$VAR[SpotColorVar2]</colordiffuse>
                     <texture>$VAR[ContextBottomVar]</texture>
                 </control>
             </control>
             <control type="grouplist">
-                <posx>754</posx>
+                <posx>714</posx>
                 <posy>0</posy>
-                <width>460</width>
+                <width>550</width>
                 <height>1080</height>
                 <itemgap>12</itemgap>
                 <orientation>vertical</orientation>

--- a/1080i/includes.xml
+++ b/1080i/includes.xml
@@ -365,7 +365,7 @@
     </include>
     <include name="Objects_ShutdownMenuButton">
         <height>75</height>
-        <width>460</width>
+        <width>550</width>
         <textcolor>context</textcolor>
         <focusedcolor>white2</focusedcolor>
         <disabledcolor>$VAR[SpotColorVar2]</disabledcolor>
@@ -374,7 +374,7 @@
         <aligny>top</aligny>
         <font>Font_Reg19_Caps</font>
         <textoffsety>15</textoffsety>
-        <textoffsetx>95</textoffsetx>
+        <textoffsetx>125</textoffsetx>
         <include condition="!Skin.HasSetting(DisableGlowbar)">ShutdownGlow</include>
         <include condition="Skin.HasSetting(DisableGlowbar)">ShutdownNoGlow</include>
     </include>


### PR DESCRIPTION
Increases the width of the shutdown menu so that the icons have more space to the edge
