### PR TITLE
Changed scaling method for banners to solve banner.jpg cropping issue.

### DIFF
--- a/1080i/Viewtype_LowList.xml
+++ b/1080i/Viewtype_LowList.xml
@@ -682,7 +682,7 @@
                             <posy>-135</posy>
                             <width>420</width>
                             <height>90</height>
-                            <aspectratio scalediffuse="false">scale</aspectratio>
+                            <aspectratio scalediffuse="false">stretch</aspectratio>
                             <fadetime>400</fadetime>
                             <visible>Skin.HasSetting(lowlistbanner)</visible>
                             <texture diffuse="thumbs/banner_mask.png" background="true" fallback="empty.png">$INFO[ListItem.Path,,../banner.jpg]</texture>


### PR DESCRIPTION
An old issue from the very beginning of 3.0
