### PR TITLE
Request: Greek-optimized fontset

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -1551,16 +1551,16 @@
             <size>36</size>
         </font>
         <font>
-            <name>Font_Reg22_Caps</name>
-            <filename>Ubuntu-C.ttf</filename>
-            <style>uppercase</style>
-            <size>37</size>
-        </font>
-        <font>
             <name>Font_Bold20_Caps</name>
             <filename>BebasNeue.ttf</filename>
             <style>uppercase bold</style>
             <size>37</size>
+        </font>
+        <font>
+            <name>Font_Reg22_Caps</name>
+            <filename>BebasNeue.ttf</filename>
+            <style>uppercase</style>
+            <size>39</size>
         </font>
         <font>
             <name>Font_Bold22_Caps</name>


### PR DESCRIPTION
OK, here's the problem: with the changes in Frodo the CAPS fonts are becoming useless, so they're being removed from the skins. This is fine with most languages, but causes a great deal of issues with Greek. To make a long story short, a lot of the labels now appear ugly when they're uppercased... One fix would be to change the problematic strings to all capital letters, but this would create issues in other cases where they're supposed to be lowercase.

An easier solution that would require merely a small addition, is to simply have a fontset specifically for such cases, which I believe affects other languages as well, not only Greek. In this fontset I switched some tags to lowercase, and made greater use of the BebasNeue font, since it is the only all-Caps font left (I've also edited the sizes accordingly). These changes have, in my opinion, a rather small effect on the skin's overall look, much less than an all-lowercase fontset would have.

Hope this is not too much of an inconvenience, and that this addition makes it to the Nox code. I'm simply trying to make the skin more appealing and beautiful for the Greek users as well. Once again, thank you for your great work.
