### PR TITLE
pvr: workaround for ListItem.HasEpg issue

### DIFF
--- a/1080i/DialogPVRChannelsOSD.xml
+++ b/1080i/DialogPVRChannelsOSD.xml
@@ -115,7 +115,7 @@
                         <font>Font_Reg12</font>
                         <textcolor>grey</textcolor>
                         <label>$INFO[ListItem.StartTime]</label>
-                        <visible>ListItem.HasEpg</visible>
+                        <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                     </control>
                     <control type="progress">
                         <posx>280</posx>
@@ -126,7 +126,7 @@
                         <lefttexture border="12,0,0,0">dialogs/progress/progress_left.png</lefttexture>
                         <midtexture border="12,0,12,0">dialogs/progress/progress_mid.png</midtexture>
                         <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
-                        <visible>ListItem.HasEpg</visible>
+                        <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                         <info>ListItem.Progress</info>
                     </control>
                     <control type="label">
@@ -137,7 +137,7 @@
                         <font>Font_Reg12</font>
                         <textcolor>grey</textcolor>
                         <label>$INFO[ListItem.EndTime]</label>
-                        <visible>ListItem.HasEpg</visible>
+                        <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                     </control>
                     <control type="image">
                         <animation effect="fade" start="100" end="20" time="800" pulse="true" condition="true">conditional</animation>
@@ -201,7 +201,7 @@
                         <font>Font_Reg12</font>
                         <textcolor>grey</textcolor>
                         <label>$INFO[ListItem.StartTime]</label>
-                        <visible>ListItem.HasEpg</visible>
+                        <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                     </control>
                     <control type="progress">
                         <posx>280</posx>
@@ -212,7 +212,7 @@
                         <lefttexture border="12,0,0,0">dialogs/progress/progress_left.png</lefttexture>
                         <midtexture border="12,0,12,0">dialogs/progress/progress_mid.png</midtexture>
                         <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
-                        <visible>ListItem.HasEpg</visible>
+                        <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                         <info>ListItem.Progress</info>
                     </control>
                     <control type="label">
@@ -223,7 +223,7 @@
                         <font>Font_Reg12</font>
                         <textcolor>grey</textcolor>
                         <label>$INFO[ListItem.EndTime]</label>
-                        <visible>ListItem.HasEpg</visible>
+                        <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                     </control>
                     <control type="image">
                         <animation effect="fade" start="100" end="20" time="800" pulse="true" condition="true">conditional</animation>

--- a/1080i/Includes_PVR.xml
+++ b/1080i/Includes_PVR.xml
@@ -45,7 +45,7 @@
                     <height>30</height>
                     <font>Font_Reg14</font>
                     <textcolor>white</textcolor>
-                    <visible>Container(11).ListItem.HasEpg</visible>
+                    <visible>Container(11).ListItem.HasEpg | !IsEmpty(Container(11).ListItem.StartTime)</visible>
                     <label>$INFO[Container(11).ListItem.StartTime]</label>
                 </control>
                 <control type="progress">
@@ -57,7 +57,7 @@
                     <lefttexture border="12,0,0,0">dialogs/progress/progress_left.png</lefttexture>
                     <midtexture border="12,0,12,0">dialogs/progress/progress_mid.png</midtexture>
                     <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
-                    <visible>Container(11).ListItem.HasEpg</visible>
+                    <visible>Container(11).ListItem.HasEpg | !IsEmpty(Container(11).ListItem.StartTime)</visible>
                     <info>Container(11).ListItem.Progress</info>
                 </control>
                 <control type="label">
@@ -68,7 +68,7 @@
                     <font>Font_Reg14</font>
                     <textcolor>white</textcolor>
                     <align>right</align>
-                    <visible>Container(11).ListItem.HasEpg</visible>
+                    <visible>Container(11).ListItem.HasEpg | !IsEmpty(Container(11).ListItem.StartTime)</visible>
                     <label>$INFO[Container(11).ListItem.EndTime]</label>
                 </control>
             </control>
@@ -138,7 +138,7 @@
                     <height>30</height>
                     <font>Font_Reg14</font>
                     <textcolor>white</textcolor>
-                    <visible>Container(12).ListItem.HasEpg</visible>
+                    <visible>Container(12).ListItem.HasEpg | !IsEmpty(Container(12).ListItem.StartTime)</visible>
                     <label>$INFO[Container(12).ListItem.StartTime]</label>
                 </control>
                 <control type="progress">
@@ -150,7 +150,7 @@
                     <lefttexture border="12,0,0,0">dialogs/progress/progress_left.png</lefttexture>
                     <midtexture border="12,0,12,0">dialogs/progress/progress_mid.png</midtexture>
                     <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
-                    <visible>Container(12).ListItem.HasEpg</visible>
+                    <visible>Container(12).ListItem.HasEpg | !IsEmpty(Container(12).ListItem.StartTime)</visible>
                     <info>Container(12).ListItem.Progress</info>
                 </control>
                 <control type="label">
@@ -161,7 +161,7 @@
                     <font>Font_Reg14</font>
                     <textcolor>white</textcolor>
                     <align>right</align>
-                    <visible>Container(12).ListItem.HasEpg</visible>
+                    <visible>Container(12).ListItem.HasEpg | !IsEmpty(Container(12).ListItem.StartTime)</visible>
                     <label>$INFO[Container(12).ListItem.EndTime]</label>
                 </control>
             </control>
@@ -267,7 +267,7 @@
                 <font>Font_Reg14</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.StartTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
             <control type="progress">
                 <posx>280</posx>
@@ -278,7 +278,7 @@
                 <lefttexture border="12,0,0,0">dialogs/progress/progress_left.png</lefttexture>
                 <midtexture border="12,0,12,0">dialogs/progress/progress_mid.png</midtexture>
                 <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                 <info>ListItem.Progress</info>
             </control>
             <control type="label">
@@ -289,7 +289,7 @@
                 <font>Font_Reg14</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.EndTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
         </itemlayout>
         <focusedlayout condition="!Skin.HasSetting(smalltvlist)" height="104" width="924">
@@ -358,7 +358,7 @@
                 <font>Font_Reg14</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.StartTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
             <control type="progress">
                 <posx>280</posx>
@@ -370,7 +370,7 @@
                 <lefttexture border="12,0,0,0">dialogs/progress/progress_left.png</lefttexture>
                 <midtexture border="12,0,12,0">dialogs/progress/progress_mid.png</midtexture>
                 <righttexture border="0,0,12,0">dialogs/progress/progress_right.png</righttexture>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                 <info>ListItem.Progress</info>
             </control>
             <control type="label">
@@ -381,7 +381,7 @@
                 <font>Font_Reg14</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.EndTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
         </focusedlayout>
         <itemlayout condition="Skin.HasSetting(smalltvlist)" height="55" width="924">
@@ -434,14 +434,14 @@
                 <font>Font_Reg15</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.StartTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
             <control type="progress">
                 <posx>700</posx>
                 <posy>29</posy>
                 <width>100</width>
                 <height>12</height>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                 <info>ListItem.Progress</info>
             </control>
             <control type="label">
@@ -452,7 +452,7 @@
                 <font>Font_Reg15</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.EndTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
         </itemlayout>
         <focusedlayout condition="Skin.HasSetting(smalltvlist)" height="55" width="924">
@@ -512,14 +512,14 @@
                 <font>Font_Reg15</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.StartTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
             <control type="progress">
                 <posx>700</posx>
                 <posy>29</posy>
                 <width>100</width>
                 <height>12</height>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
                 <info>ListItem.Progress</info>
             </control>
             <control type="label">
@@ -530,7 +530,7 @@
                 <font>Font_Reg15</font>
                 <textcolor>grey</textcolor>
                 <label>$INFO[ListItem.EndTime]</label>
-                <visible>ListItem.HasEpg</visible>
+                <visible>ListItem.HasEpg | !IsEmpty(ListItem.StartTime)</visible>
             </control>
         </focusedlayout>
     </include>


### PR DESCRIPTION
This PR is a workaround for the issue #428.

It adds an additional OR condition `!IsEmpty(ListItem.StartTime)` to all visibility conditions where ListItem.HasEpg is used. If ListItem.HasEpg works like expected, we can easily revert this.
