### PR TITLE
pvr: if expanded recording icon is default show fallback_record or

### DIFF
--- a/1080i/MyPVR.xml
+++ b/1080i/MyPVR.xml
@@ -124,7 +124,7 @@
                 <height>448</height>
                 <texture>$INFO[Container(13).ListItem.Icon]</texture>
                 <include>Animation_VisibleChange200</include>
-                <visible>!Player.HasVideo + Control.IsVisible(13) + !IsEmpty(Container(13).ListItem.Icon)</visible>
+                <visible>!Player.HasVideo + Control.IsVisible(13) + !StringCompare(Container(13).ListItem.Icon,DefaultVideo.png)</visible>
             </control>
             <control type="image">
                 <posx>5</posx>
@@ -133,7 +133,7 @@
                 <height>448</height>
                 <texture fallback="special://skin/backgrounds/fallback_record.jpg">$INFO[Skin.String(LiveTVHomeItem.MultiFanart)]</texture>
                 <include>Animation_VisibleChange200</include>
-                <visible>!Player.HasVideo + Control.IsVisible(13) + IsEmpty(Container(13).ListItem.Icon)</visible>
+                <visible>!Player.HasVideo + Control.IsVisible(13) + StringCompare(Container(13).ListItem.Icon,DefaultVideo.png)</visible>
             </control>
             <control type="videowindow">
                 <posx>5</posx>


### PR DESCRIPTION
custom background image in recording view
