### PR TITLE
Allow viewtype episode settings to appear on content(episodes)

### DIFF
--- a/1080i/custom_1126_ViewtypeSettings.xml
+++ b/1080i/custom_1126_ViewtypeSettings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <window type="dialog" id="1126">
     <defaultcontrol always="true">450</defaultcontrol>
     <zorder>0</zorder>
@@ -403,7 +403,7 @@
                 <onclick condition="Skin.HasSetting(disableepisodeposter)">Skin.SetBool(EpisodeViewIcon)</onclick>
                 <onclick condition="Skin.HasSetting(disableepisodeposter)">Skin.Reset(disableepisodeposter)</onclick>
                 <onclick condition="Skin.HasSetting(EpisodeViewIcon)">Skin.Reset(EpisodeViewIcon)</onclick>
-                <visible>[Container.Content(seasons) | Container.Content(tvshows)] + Stringcompare(Window(home).Property(actualViewtype),Episode)</visible>
+                <visible>[Container.Content(seasons) | Container.Content(tvshows) | Container.Content(episodes)] + Stringcompare(Window(home).Property(actualViewtype),Episode)</visible>
             </control>
             <control type="radiobutton" id="1663">
                 <include>Objects_MediaMenuButtonAlt2</include>


### PR DESCRIPTION
I have the feeling that this settings on episode viewtype where also meant to be shown when browsing episodes as it indeed modifies the behavior of the view (show poster on left). Included a patch to add this.

A couple of further questions on the Episode viewtype when showing episodes:
1. Season poster do not work ... is it suppose it? 
2. Logos are also not shown ... is it suppose to show the TVshow logo at the top or bottom of the poster? 

I can give it a try to fix these problems if so...
