### PR TITLE
Featured window labels color fix (White theme)

### DIFF
--- a/1080i/custom_1115_Featured.xml
+++ b/1080i/custom_1115_Featured.xml
@@ -396,7 +396,6 @@
                             <width>746</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(5002).ListItem.Label2,,: ]$INFO[Container(5002).ListItem.Property(EpisodeNo),, - ]$INFO[Container(5002).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>
@@ -559,7 +558,6 @@
                             <width>272</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(5003).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>
@@ -818,7 +816,6 @@
                             <width>746</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(6002).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>
@@ -970,7 +967,6 @@
                             <width>272</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(6003).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>
@@ -1221,7 +1217,6 @@
                             <width>746</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(7002).ListItem.Label2,,: ]$INFO[Container(7002).ListItem.Property(EpisodeNumber),, - ]$INFO[Container(7002).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>
@@ -1993,7 +1988,6 @@
                             <width>402</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(8002).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>
@@ -2474,7 +2468,6 @@
                             <width>402</width>
                             <height>40</height>
                             <font>Font_Reg15</font>
-                            <textcolor>FFe5e5e5</textcolor>
                             <label>$INFO[Container(9002).ListItem.Label]</label>
                             <textoffsetx>15</textoffsetx>
                         </control>


### PR DESCRIPTION
A few days ago I added these textcolors I am now removing, because the Featured window labels where not very discernible in the White theme (black text in front of a black bar). And indeed this worked... with an old White.xbt file. Today I ran TexturePacker to create an updated White.xbt, only to find out this black bar had been updated at some point for the White theme, therefore these textcolors are no longer needed (they actually make the labels less visible). This PR does not effect the Default theme.
