### PR TITLE
A fix to show a TV banner and a logo in LowList instead of double logos

### DIFF
--- a/1080i/Viewtype_LowList.xml
+++ b/1080i/Viewtype_LowList.xml
@@ -695,11 +695,12 @@
                             <visible>!StringCompare(Control.GetLabel(2244),empty.png)</visible>
                         </control>
                         <control type="image">
-                            <posy>-165</posy>
-                            <width>390</width>
-                            <height>150</height>
-                            <fadetime>400</fadetime>
-                            <texture background="true">$VAR[TVShowLogoVar]</texture>
+                            <posy>-135</posy>
+                            <width>420</width>
+                            <height>90</height>
+                            <aspectratio scalediffuse="false">stretch</aspectratio>
+                            <fadetime>400</fadetime> 
+                            <texture diffuse="thumbs/banner_mask.png" background="true" fallback="empty.png">$VAR[BannerVar]</texture>
                             <visible>Container.Content(episodes) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(movies)</visible>
                             <visible>!Skin.HasSetting(lowlistbanner)</visible>
                         </control>


### PR DESCRIPTION
Show a TV banner at the left side of LowList instead of 2 identical logos at the right and left.
