### PR TITLE
TV Guide: Color fix for white themes

### DIFF
--- a/1080i/Includes_NextAired.xml
+++ b/1080i/Includes_NextAired.xml
@@ -82,6 +82,7 @@
                     <height>100</height>
                     <aspectratio>keep</aspectratio>
                     <texture>tvguide/$INFO[ListItem.Property(StatusID)].png</texture>
+                    <colordiffuse>floor</colordiffuse>
                 </control>
                 <control type="image">
                     <posx>20</posx>
@@ -89,6 +90,7 @@
                     <width>35</width>
                     <height>35</height>
                     <texture>tvguide/clock.png</texture>
+                    <colordiffuse>floor</colordiffuse>
                 </control>
                 <control type="label">
                     <posx>215</posx>
@@ -167,7 +169,6 @@
                 <aspectratio>keep</aspectratio>
                 <texture>$INFO[ListItem.Property(Art(characterart))]</texture>
                 <fadetime>IconCrossfadeTime2</fadetime>
-                <colordiffuse>floor</colordiffuse>
                 <animation effect="fade" time="200">VisibleChange</animation>
             </control>
             <control type="image">


### PR DESCRIPTION
Some icons (like the characterart) appeared black in TV Guide in white themes.
