### PR TITLE
Latest movies widget displaying other profile movies.

### DIFF
--- a/1080i/Includes_Widget1.xml
+++ b/1080i/Includes_Widget1.xml
@@ -38,6 +38,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.2.Title)]</label>
@@ -76,6 +77,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.3.Title)]</label>
@@ -114,6 +116,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.4.Title)]</label>
@@ -152,6 +155,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.5.Title)]</label>
@@ -190,6 +194,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.6.Title)]</label>
@@ -228,6 +233,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.7.Title)]</label>
@@ -266,6 +272,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist1.8.Title)]</label>
@@ -304,6 +311,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist1.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),1custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist1.8.Title))</visible>
         </item>
     </include>
     <include name="Custom2Widget">
@@ -344,6 +352,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.2.Title)]</label>
@@ -382,6 +391,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.3.Title)]</label>
@@ -420,6 +430,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.4.Title)]</label>
@@ -458,6 +469,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.5.Title)]</label>
@@ -496,6 +508,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.6.Title)]</label>
@@ -534,6 +547,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.7.Title)]</label>
@@ -572,6 +586,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist2.8.Title)]</label>
@@ -610,6 +625,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist2.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),2custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist2.8.Title))</visible>
         </item>
     </include>
     <include name="Custom3Widget">
@@ -650,6 +666,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.2.Title)]</label>
@@ -688,6 +705,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.3.Title)]</label>
@@ -726,6 +744,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.4.Title)]</label>
@@ -764,6 +783,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.5.Title)]</label>
@@ -802,6 +822,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.6.Title)]</label>
@@ -840,6 +861,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.7.Title)]</label>
@@ -878,6 +900,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist3.8.Title)]</label>
@@ -916,6 +939,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist3.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),3custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist3.8.Title))</visible>
         </item>
     </include>
     <include name="Custom4Widget">
@@ -956,6 +980,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.2.Title)]</label>
@@ -994,6 +1019,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.3.Title)]</label>
@@ -1032,6 +1058,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.4.Title)]</label>
@@ -1070,6 +1097,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.5.Title)]</label>
@@ -1108,6 +1136,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.6.Title)]</label>
@@ -1146,6 +1175,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.7.Title)]</label>
@@ -1184,6 +1214,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist4.8.Title)]</label>
@@ -1222,6 +1253,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist4.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),4custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist4.8.Title))</visible>
         </item>
     </include>
     <include name="Custom5Widget">
@@ -1262,6 +1294,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.2.Title)]</label>
@@ -1300,6 +1333,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.3.Title)]</label>
@@ -1338,6 +1372,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.4.Title)]</label>
@@ -1376,6 +1411,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.5.Title)]</label>
@@ -1414,6 +1450,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.6.Title)]</label>
@@ -1452,6 +1489,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.7.Title)]</label>
@@ -1490,6 +1528,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist5.8.Title)]</label>
@@ -1528,6 +1567,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist5.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),5custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist5.8.Title))</visible>
         </item>
     </include>
     <include name="Custom6Widget">
@@ -1568,6 +1608,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.2.Title)]</label>
@@ -1606,6 +1647,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.3.Title)]</label>
@@ -1644,6 +1686,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.4.Title)]</label>
@@ -1682,6 +1725,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.5.Title)]</label>
@@ -1720,6 +1764,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.6.Title)]</label>
@@ -1758,6 +1803,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.7.Title)]</label>
@@ -1796,6 +1842,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist6.8.Title)]</label>
@@ -1834,6 +1881,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist6.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),6custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist6.8.Title))</visible>
         </item>
     </include>
     <include name="MusicvideoLatestItems">
@@ -1856,7 +1904,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.1.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.1.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.2.Title)]</label>
@@ -1877,7 +1925,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.2.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.2.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.3.Title)]</label>
@@ -1898,7 +1946,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.3.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.3.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.4.Title)]</label>
@@ -1919,7 +1967,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.4.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.4.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.5.Title)]</label>
@@ -1940,7 +1988,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.5.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.5.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.6.Title)]</label>
@@ -1961,7 +2009,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.6.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.6.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.7.Title)]</label>
@@ -1982,7 +2030,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.7.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.7.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.8.Title)]</label>
@@ -2003,7 +2051,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.8.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.8.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.8.Title))</visible>
         </item>
     </include>
     <include name="MusicvideoRandomItems">
@@ -2026,7 +2074,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.1.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.1.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.2.Title)]</label>
@@ -2047,7 +2095,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.2.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.2.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.3.Title)]</label>
@@ -2068,7 +2116,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.3.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.3.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.4.Title)]</label>
@@ -2089,7 +2137,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.4.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.4.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.5.Title)]</label>
@@ -2110,7 +2158,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.5.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.5.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.6.Title)]</label>
@@ -2131,7 +2179,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.6.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.6.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.7.Title)]</label>
@@ -2152,7 +2200,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.7.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.7.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.8.Title)]</label>
@@ -2173,7 +2221,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.8.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.8.Plot)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.8.Title))</visible>
         </item>
     </include>
     <include name="WatchListMusicVideosItems">
@@ -2696,7 +2744,7 @@
             <property name="NavItem">item1.png</property>
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.1.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.2.Title)]</label>
@@ -2733,7 +2781,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.2.DBID)]</property>
             <property name="NavItem">item2.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.3.Title)]</label>
@@ -2770,7 +2818,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.3.DBID)]</property>
             <property name="NavItem">item3.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.4.Title)]</label>
@@ -2807,7 +2855,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.4.DBID)]</property>
             <property name="NavItem">item4.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.5.Title)]</label>
@@ -2844,7 +2892,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.5.DBID)]</property>
             <property name="NavItem">item5.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.6.Title)]</label>
@@ -2881,7 +2929,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.6.DBID)]</property>
             <property name="NavItem">item6.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.7.Title)]</label>
@@ -2918,7 +2966,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.7.DBID)]</property>
             <property name="NavItem">item7.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.8.Title)]</label>
@@ -2955,7 +3003,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.8.DBID)]</property>
             <property name="NavItem">item8.png</property>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4321),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.8.Title))</visible>
         </item>
     </include>
     <include name="LatestMoviesItems">
@@ -3266,6 +3314,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.1.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.1.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.2.Name)]</label>
@@ -3276,6 +3325,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.2.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.2.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.3.Name)]</label>
@@ -3286,6 +3336,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.3.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.3.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.4.Name)]</label>
@@ -3296,6 +3347,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.4.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.4.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.5.Name)]</label>
@@ -3306,6 +3358,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.5.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.5.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.6.Name)]</label>
@@ -3316,6 +3369,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.6.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.6.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.7.Name)]</label>
@@ -3326,6 +3380,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.7.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.7.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.8.Name)]</label>
@@ -3336,6 +3391,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.8.icon)]</icon>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.8.Name))</visible>
         </item>
     </include>
     <include name="RandomAddonsItems">
@@ -3348,7 +3404,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.1.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.1.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.2.Title)]</label>
@@ -3359,7 +3415,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.2.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.2.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.3.Title)]</label>
@@ -3370,7 +3426,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.3.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.3.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.4.Title)]</label>
@@ -3381,7 +3437,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.4.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.4.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.5.Title)]</label>
@@ -3392,7 +3448,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.5.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.5.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.5.Title))</visible>
         </item>
     </include>
     <include name="RandomAddonsItemsHome">
@@ -3405,7 +3461,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.6.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.6.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.7.Title)]</label>
@@ -3416,7 +3472,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.7.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.7.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.8.Title)]</label>
@@ -3427,7 +3483,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.8.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.8.Art(thumb))]</icon>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.8.Title))</visible>
         </item>
     </include>
     <include name="WatchlistMusicItems">
@@ -3449,6 +3505,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.2.Title)]</label>
@@ -3468,6 +3525,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.3.Title)]</label>
@@ -3487,6 +3545,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.4.Title)]</label>
@@ -3506,6 +3565,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.5.Title)]</label>
@@ -3525,6 +3585,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.5.Title))</visible>
         </item>
     </include>
     <include name="WatchlistMusicItemsHome">
@@ -3546,6 +3607,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.7.Title)]</label>
@@ -3565,6 +3627,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.8.Title)]</label>
@@ -3584,6 +3647,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.8.Title))</visible>
         </item>
     </include>
     <include name="RandomAlbumsItems">
@@ -3605,7 +3669,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.2.Title)]</label>
@@ -3625,7 +3689,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.3.Title)]</label>
@@ -3645,7 +3709,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.4.Title)]</label>
@@ -3665,7 +3729,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.5.Title)]</label>
@@ -3685,7 +3749,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.5.Title))</visible>
         </item>
     </include>
     <include name="RandomAlbumsItemsHome">
@@ -3707,7 +3771,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.7.Title)]</label>
@@ -3727,7 +3791,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.8.Title)]</label>
@@ -3747,7 +3811,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.8.Title))</visible>
         </item>
     </include>
     <include name="RandomArtistsItems">
@@ -3769,7 +3833,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.1.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.2.Title)]</label>
@@ -3789,7 +3853,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.2.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.3.Title)]</label>
@@ -3809,7 +3873,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.3.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.4.Title)]</label>
@@ -3829,7 +3893,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.4.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.5.Title)]</label>
@@ -3849,7 +3913,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.5.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.5.Title))</visible>
         </item>
     </include>
     <include name="RandomArtistsItemsHome">
@@ -3871,7 +3935,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.6.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.7.Title)]</label>
@@ -3891,7 +3955,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.7.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.8.Title)]</label>
@@ -3911,7 +3975,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.8.Art(thumb))]</thumb>
             <onclick>SetFocus(5014)</onclick>
-            <visible>Substring(Control.GetLabel(4321),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.8.Title))</visible>
         </item>
     </include>
     <include name="LatestAlbumsItems">
@@ -4331,7 +4395,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.1.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.1.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.2.Title)]</label>
@@ -4357,7 +4421,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.2.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.2.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.3.Title)]</label>
@@ -4383,7 +4447,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.3.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.3.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.4.Title)]</label>
@@ -4409,7 +4473,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.4.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.4.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.4.Title))</visible>
         </item>
     </include>
     <include name="RandomEpisodesItemsHome">
@@ -4437,7 +4501,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.5.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.5.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.6.Title)]</label>
@@ -4463,7 +4527,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.6.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.6.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.7.Title)]</label>
@@ -4489,7 +4553,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.7.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.7.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.8.Title)]</label>
@@ -4515,7 +4579,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.8.DBID)]</property>
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.8.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4321),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4321),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.8.Title))</visible>
         </item>
     </include>
     <include name="LatestEpisodesItems">
@@ -4747,6 +4811,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.1.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.1.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.2.Name)]</label>
@@ -4756,6 +4821,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.2.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.2.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.3.Name)]</label>
@@ -4765,6 +4831,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.3.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.3.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.4.Name)]</label>
@@ -4774,6 +4841,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.4.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.4.Name))</visible>
         </item>
     </include>
     <include name="RandomPicturesItemsHome">
@@ -4785,6 +4853,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.5.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.5.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.6.Name)]</label>
@@ -4794,6 +4863,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.6.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.6.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.7.Name)]</label>
@@ -4803,6 +4873,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.7.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.7.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.8.Name)]</label>
@@ -4812,6 +4883,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.8.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.8.Name))</visible>
         </item>
     </include>
     <include name="LatestPicturesItems">
@@ -4823,6 +4895,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.1.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.1.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.2.Name)]</label>
@@ -4832,6 +4905,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.2.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.2.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.3.Name)]</label>
@@ -4841,6 +4915,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.3.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.3.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.4.Name)]</label>
@@ -4850,6 +4925,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.4.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.4.Name))</visible>
         </item>
     </include>
     <include name="LatestPicturesItemsHome">
@@ -4861,6 +4937,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.5.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.5.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.6.Name)]</label>
@@ -4870,6 +4947,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.6.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.6.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.7.Name)]</label>
@@ -4879,6 +4957,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.7.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.7.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.8.Name)]</label>
@@ -4888,6 +4967,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.8.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4321),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.8.Name))</visible>
         </item>
     </include>
     <include name="MostPlayedRomsItems">
@@ -4904,6 +4984,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.1.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.2.Title)]</label>
@@ -4918,6 +4999,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.2.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.3.Title)]</label>
@@ -4932,6 +5014,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.3.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.4.Title)]</label>
@@ -4946,6 +5029,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.4.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.5.Title)]</label>
@@ -4960,6 +5044,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.5.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.6.Title)]</label>
@@ -4974,6 +5059,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.6.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.7.Title)]</label>
@@ -4988,6 +5074,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.7.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.8.Title)]</label>
@@ -5002,6 +5089,7 @@
             <onclick>SetFocus(5014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.8.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4321),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.8.Title))</visible>
         </item>
     </include>
     <include name="RSS1WidgetContent1124">
@@ -5598,6 +5686,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.0.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.0.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.1.title)]</label>
@@ -5606,6 +5695,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.1.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.1.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.2.title)]</label>
@@ -5614,6 +5704,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.2.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.2.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.3.title)]</label>
@@ -5622,6 +5713,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.3.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.3.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.4.title)]</label>
@@ -5630,6 +5722,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.4.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.4.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.5.title)]</label>
@@ -5638,6 +5731,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.5.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.5.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.6.title)]</label>
@@ -5646,6 +5740,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.6.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.6.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.7.title)]</label>
@@ -5654,6 +5749,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.7.pic)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.7.title))</visible>
         </item>
     </include>
     <include name="XKCDContent">
@@ -5663,6 +5759,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.0.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.0.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.1.Title)]</label>
@@ -5670,6 +5767,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.1.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.2.Title)]</label>
@@ -5677,6 +5775,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.2.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.3.Title)]</label>
@@ -5684,6 +5783,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.3.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.4.Title)]</label>
@@ -5691,6 +5791,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.4.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.5.Title)]</label>
@@ -5698,6 +5799,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.5.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.6.Title)]</label>
@@ -5705,6 +5807,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.6.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.7.Title)]</label>
@@ -5712,6 +5815,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.7.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.7.Title))</visible>
         </item>
     </include>
     <include name="CyanideContent">
@@ -5720,48 +5824,56 @@
             <thumb>$INFO[Window(home).Property(CyanideHappiness.1.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.2.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.2.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.3.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.3.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.4.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.4.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.5.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.5.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.6.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.6.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.7.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.7.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.8.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.8.Image)]</thumb>
             <onclick>SetFocus(5014)</onclick>
             <visible>Substring(Control.GetLabel(4321),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.8.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidgetLeftMovies">
@@ -5775,6 +5887,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.1.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.1.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.2.Title)]</label>
@@ -5786,6 +5899,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.2.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.2.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.3.Title)]</label>
@@ -5797,6 +5911,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.3.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.3.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.4.Title)]</label>
@@ -5808,6 +5923,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.4.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.4.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.5.Title)]</label>
@@ -5819,6 +5935,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.5.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.5.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.6.Title)]</label>
@@ -5830,6 +5947,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.6.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.6.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.7.Title)]</label>
@@ -5841,6 +5959,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.7.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.7.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.8.Title)]</label>
@@ -5852,6 +5971,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.8.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.8.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.8.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidgetLeftTV">
@@ -5862,6 +5982,7 @@
             <property name="NavItem">item1.png</property>
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RecommendedEpisode.1.Art(thumb))]</icon>
             <onclick>$INFO[Window(Home).Property(RecommendedEpisode.1.Play)]</onclick>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedEpisode.1.Title))</visible>
             <visible>Substring(Control.GetLabel(4321),featuredtv)</visible>
         </item>
         <item>
@@ -5946,6 +6067,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.1.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.2.Title)]</label>
@@ -5957,6 +6079,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.2.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.3.Title)]</label>
@@ -5968,6 +6091,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.3.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.4.Title)]</label>
@@ -5979,6 +6103,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.4.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.5.Title)]</label>
@@ -5990,6 +6115,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.5.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.6.Title)]</label>
@@ -6001,6 +6127,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.6.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.7.Title)]</label>
@@ -6012,6 +6139,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.7.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.8.Title)]</label>
@@ -6023,6 +6151,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.8.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.8.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidgetMiddleMovies">
@@ -6090,6 +6219,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.11.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.11.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.1.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.11.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.12.Title)]</label>
@@ -6100,6 +6230,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.12.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.12.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.2.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.12.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.13.Title)]</label>
@@ -6110,6 +6241,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.13.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.13.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.3.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.13.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.14.Title)]</label>
@@ -6120,6 +6252,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.14.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.14.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.4.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.14.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.15.Title)]</label>
@@ -6130,6 +6263,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.15.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.15.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.5.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.15.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidgetMiddleTV">
@@ -6141,6 +6275,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.1.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.1.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.2.Title)]</label>
@@ -6150,6 +6285,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.2.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.2.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.3.Title)]</label>
@@ -6159,6 +6295,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.3.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.3.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.4.Title)]</label>
@@ -6168,6 +6305,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.4.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.4.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.5.Title)]</label>
@@ -6177,6 +6315,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.5.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.5.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.5.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidgetMiddleMusic">
@@ -6190,6 +6329,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.1.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.2.Title)]</label>
@@ -6201,6 +6341,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.2.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.3.Title)]</label>
@@ -6212,6 +6353,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.3.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.4.Title)]</label>
@@ -6223,6 +6365,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.4.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.5.Title)]</label>
@@ -6234,6 +6377,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.5.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4321),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.5.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidgetRightMovies">

--- a/1080i/Includes_Widget2.xml
+++ b/1080i/Includes_Widget2.xml
@@ -38,6 +38,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.2.Title)]</label>
@@ -76,6 +77,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.3.Title)]</label>
@@ -114,6 +116,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.4.Title)]</label>
@@ -152,6 +155,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.5.Title)]</label>
@@ -190,6 +194,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.6.Title)]</label>
@@ -228,6 +233,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.7.Title)]</label>
@@ -266,6 +272,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist7.8.Title)]</label>
@@ -304,6 +311,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist7.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),7custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist7.8.Title))</visible>
         </item>
     </include>
     <include name="Custom2Widget2">
@@ -344,6 +352,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.2.Title)]</label>
@@ -382,6 +391,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.3.Title)]</label>
@@ -420,6 +430,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.4.Title)]</label>
@@ -458,6 +469,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.5.Title)]</label>
@@ -496,6 +508,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.6.Title)]</label>
@@ -534,6 +547,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.7.Title)]</label>
@@ -572,6 +586,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist8.8.Title)]</label>
@@ -610,6 +625,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist8.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),8custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist8.8.Title))</visible>
         </item>
     </include>
     <include name="Custom3Widget2">
@@ -650,6 +666,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.2.Title)]</label>
@@ -688,6 +705,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.3.Title)]</label>
@@ -726,6 +744,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.4.Title)]</label>
@@ -764,6 +783,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.5.Title)]</label>
@@ -802,6 +822,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.6.Title)]</label>
@@ -840,6 +861,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.7.Title)]</label>
@@ -878,6 +900,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist9.8.Title)]</label>
@@ -916,6 +939,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist9.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),9custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist9.8.Title))</visible>
         </item>
     </include>
     <include name="Custom4Widget2">
@@ -956,6 +980,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.2.Title)]</label>
@@ -994,6 +1019,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.3.Title)]</label>
@@ -1032,6 +1058,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.4.Title)]</label>
@@ -1070,6 +1097,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.5.Title)]</label>
@@ -1108,6 +1136,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.6.Title)]</label>
@@ -1146,6 +1175,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.7.Title)]</label>
@@ -1184,6 +1214,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist10.8.Title)]</label>
@@ -1222,6 +1253,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist10.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),10custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist10.8.Title))</visible>
         </item>
     </include>
     <include name="Custom5Widget2">
@@ -1262,6 +1294,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.2.Title)]</label>
@@ -1300,6 +1333,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.3.Title)]</label>
@@ -1338,6 +1372,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.4.Title)]</label>
@@ -1376,6 +1411,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.5.Title)]</label>
@@ -1414,6 +1450,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.6.Title)]</label>
@@ -1452,6 +1489,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.7.Title)]</label>
@@ -1490,6 +1528,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist11.8.Title)]</label>
@@ -1528,6 +1567,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist11.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),11custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist11.8.Title))</visible>
         </item>
     </include>
     <include name="Custom6Widget2">
@@ -1568,6 +1608,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.2.Title)]</label>
@@ -1606,6 +1647,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.3.Title)]</label>
@@ -1644,6 +1686,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.4.Title)]</label>
@@ -1682,6 +1725,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.5.Title)]</label>
@@ -1720,6 +1764,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.6.Title)]</label>
@@ -1758,6 +1803,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.7.Title)]</label>
@@ -1796,6 +1842,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(SmartPlaylist12.8.Title)]</label>
@@ -1834,6 +1881,7 @@
             <thumb>$INFO[Window(Home).Property(SmartPlaylist12.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),12custom)</visible>
+			<visible>!IsEmpty(Window(Home).Property(SmartPlaylist12.8.Title))</visible>
         </item>
     </include>
     <include name="MusicvideoLatestItems2">
@@ -1856,7 +1904,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.1.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.1.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.2.Title)]</label>
@@ -1877,7 +1925,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.2.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.2.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.3.Title)]</label>
@@ -1898,7 +1946,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.3.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.3.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.4.Title)]</label>
@@ -1919,7 +1967,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.4.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.4.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.5.Title)]</label>
@@ -1940,7 +1988,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.5.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.5.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.6.Title)]</label>
@@ -1961,7 +2009,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.6.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.6.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.7.Title)]</label>
@@ -1982,7 +2030,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.7.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.7.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.8.Title)]</label>
@@ -2003,7 +2051,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RecentMusicVideo.8.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RecentMusicVideo.8.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),recentmusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),recentmusicvideos) + !IsEmpty(Window(Home).Property(RecentMusicVideo.8.Title))</visible>
         </item>
     </include>
     <include name="MusicvideoRandomItems2">
@@ -2026,7 +2074,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.1.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.1.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.2.Title)]</label>
@@ -2047,7 +2095,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.2.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.2.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.3.Title)]</label>
@@ -2068,7 +2116,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.3.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.3.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.4.Title)]</label>
@@ -2089,7 +2137,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.4.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.4.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.5.Title)]</label>
@@ -2110,7 +2158,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.5.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.5.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.6.Title)]</label>
@@ -2131,7 +2179,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.6.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.6.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.7.Title)]</label>
@@ -2152,7 +2200,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.7.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.7.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMusicVideo.8.Title)]</label>
@@ -2173,7 +2221,7 @@
             <property name="Poster">$INFO[Window(Home).Property(RandomMusicVideo.8.Art(thumb))]</property>
             <property name="Plot">$INFO[Window(Home).Property(RandomMusicVideo.8.Plot)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommusicvideos)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommusicvideos) + !IsEmpty(Window(Home).Property(RandomMusicVideo.8.Title))</visible>
         </item>
     </include>
     <include name="WatchListMusicVideosItems2">
@@ -2669,7 +2717,7 @@
             <property name="NavItem">item1.png</property>
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.1.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.2.Title)]</label>
@@ -2703,7 +2751,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.2.DBID)]</property>
             <property name="NavItem">item2.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.3.Title)]</label>
@@ -2737,7 +2785,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.3.DBID)]</property>
             <property name="NavItem">item3.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.4.Title)]</label>
@@ -2771,7 +2819,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.4.DBID)]</property>
             <property name="NavItem">item4.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.5.Title)]</label>
@@ -2805,7 +2853,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.5.DBID)]</property>
             <property name="NavItem">item5.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.6.Title)]</label>
@@ -2839,7 +2887,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.6.DBID)]</property>
             <property name="NavItem">item6.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.7.Title)]</label>
@@ -2873,7 +2921,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.7.DBID)]</property>
             <property name="NavItem">item7.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.8.Title)]</label>
@@ -2907,7 +2955,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomMovie.8.DBID)]</property>
             <property name="NavItem">item8.png</property>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randommovies)</visible>
+            <visible>Substring(Control.GetLabel(4325),randommovies) + !IsEmpty(Window(Home).Property(RandomMovie.8.Title))</visible>
         </item>
     </include>
     <include name="LatestMoviesItems2">
@@ -3194,6 +3242,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.1.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.1.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.2.Name)]</label>
@@ -3204,6 +3253,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.2.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.2.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.3.Name)]</label>
@@ -3214,6 +3264,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.3.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.3.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.4.Name)]</label>
@@ -3224,6 +3275,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.4.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.4.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.5.Name)]</label>
@@ -3234,6 +3286,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.5.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.5.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.6.Name)]</label>
@@ -3244,6 +3297,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.6.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.6.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.7.Name)]</label>
@@ -3254,6 +3308,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.7.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.7.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(peopleborntoday.8.Name)]</label>
@@ -3264,6 +3319,7 @@
             <icon>$INFO[Window(Home).Property(peopleborntoday.8.icon)]</icon>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),actors)</visible>
+			<visible>!IsEmpty(Window(Home).Property(peopleborntoday.8.Name))</visible>
         </item>
     </include>
     <include name="RandomAddonsItems2">
@@ -3276,7 +3332,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.1.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.1.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.2.Title)]</label>
@@ -3287,7 +3343,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.2.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.2.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.3.Title)]</label>
@@ -3298,7 +3354,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.3.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.3.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.4.Title)]</label>
@@ -3309,7 +3365,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.4.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.4.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.5.Title)]</label>
@@ -3320,7 +3376,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.5.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.5.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.5.Title))</visible>
         </item>
     </include>
     <include name="RandomAddonsItems2Home">
@@ -3333,7 +3389,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.6.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.6.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.7.Title)]</label>
@@ -3344,7 +3400,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.7.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.7.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAddon.8.Title)]</label>
@@ -3355,7 +3411,7 @@
             <property name="Version">$INFO[Window(Home).Property(RandomAddon.8.Version)]</property>
             <icon>$INFO[Window(Home).Property(RandomAddon.8.Art(thumb))]</icon>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomaddons)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomaddons) + !IsEmpty(Window(Home).Property(RandomAddon.8.Title))</visible>
         </item>
     </include>
     <include name="WatchlistMusicItems2">
@@ -3373,6 +3429,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.2.Title)]</label>
@@ -3388,6 +3445,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.3.Title)]</label>
@@ -3403,6 +3461,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.4.Title)]</label>
@@ -3418,6 +3477,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.5.Title)]</label>
@@ -3433,6 +3493,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.5.Title))</visible>
         </item>
     </include>
     <include name="WatchlistMusicItems2Home">
@@ -3450,6 +3511,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.7.Title)]</label>
@@ -3465,6 +3527,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.8.Title)]</label>
@@ -3480,6 +3543,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),watchlistalbums)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.8.Title))</visible>
         </item>
     </include>
     <include name="RandomAlbumsItems2">
@@ -3497,7 +3561,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.2.Title)]</label>
@@ -3513,7 +3577,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.3.Title)]</label>
@@ -3529,7 +3593,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.4.Title)]</label>
@@ -3545,7 +3609,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.5.Title)]</label>
@@ -3561,7 +3625,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.5.Title))</visible>
         </item>
     </include>
     <include name="RandomAlbumsItems2Home">
@@ -3579,7 +3643,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.7.Title)]</label>
@@ -3595,7 +3659,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.8.Title)]</label>
@@ -3611,7 +3675,7 @@
             <icon>DefaultAlbumCover.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomAlbum.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomalbums)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomalbums) + !IsEmpty(Window(Home).Property(RandomAlbum.8.Title))</visible>
         </item>
     </include>
     <include name="RandomArtistsItems2">
@@ -3633,7 +3697,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.1.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.2.Title)]</label>
@@ -3653,7 +3717,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.2.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.3.Title)]</label>
@@ -3673,7 +3737,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.3.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.4.Title)]</label>
@@ -3693,7 +3757,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.4.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.5.Title)]</label>
@@ -3713,7 +3777,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.5.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.5.Title))</visible>
         </item>
     </include>
     <include name="RandomArtistsItems2Home">
@@ -3735,7 +3799,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.6.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.7.Title)]</label>
@@ -3755,7 +3819,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.7.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomArtist.8.Title)]</label>
@@ -3775,7 +3839,7 @@
             <icon>DefaultArtist.png</icon>
             <thumb>$INFO[Window(Home).Property(RandomArtist.8.Art(thumb))]</thumb>
             <onclick>SetFocus(6014)</onclick>
-            <visible>Substring(Control.GetLabel(4325),randomartists)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomartists) + !IsEmpty(Window(Home).Property(RandomArtist.8.Title))</visible>
         </item>
     </include>
     <include name="LatestAlbumsItems2">
@@ -4195,7 +4259,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.1.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.1.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.2.Title)]</label>
@@ -4221,7 +4285,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.2.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.2.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.3.Title)]</label>
@@ -4247,7 +4311,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.3.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.3.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.4.Title)]</label>
@@ -4273,7 +4337,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.4.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.4.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.4.Title))</visible>
         </item>
     </include>
     <include name="RandomEpisodesItems2Home">
@@ -4301,7 +4365,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.5.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.5.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.6.Title)]</label>
@@ -4327,7 +4391,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.6.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.6.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.7.Title)]</label>
@@ -4353,7 +4417,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.7.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.7.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.8.Title)]</label>
@@ -4379,7 +4443,7 @@
             <property name="DBID">$INFO[Window(Home).Property(RandomEpisode.8.DBID)]</property>
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(RandomEpisode.8.Art(thumb))]</thumb>
-            <visible>Substring(Control.GetLabel(4325),randomtv)</visible>
+            <visible>Substring(Control.GetLabel(4325),randomtv) + !IsEmpty(Window(Home).Property(RandomEpisode.8.Title))</visible>
         </item>
     </include>
     <include name="LatestEpisodesItems2">
@@ -4603,6 +4667,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.1.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.1.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.2.Name)]</label>
@@ -4612,6 +4677,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.2.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.2.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.3.Name)]</label>
@@ -4621,6 +4687,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.3.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.3.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.4.Name)]</label>
@@ -4630,6 +4697,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.4.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.4.Name))</visible>
         </item>
     </include>
     <include name="RandomPicturesItems2Home">
@@ -4641,6 +4709,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.5.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.5.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.6.Name)]</label>
@@ -4650,6 +4719,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.6.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.6.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.7.Name)]</label>
@@ -4659,6 +4729,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.7.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.7.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBRandom.8.Name)]</label>
@@ -4668,6 +4739,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBRandom.8.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),randompics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBRandom.8.Name))</visible>
         </item>
     </include>
     <include name="LatestPicturesItems2">
@@ -4679,6 +4751,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.1.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.1.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.2.Name)]</label>
@@ -4688,6 +4761,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.2.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.2.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.3.Name)]</label>
@@ -4697,6 +4771,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.3.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.3.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.4.Name)]</label>
@@ -4706,6 +4781,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.4.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.4.Name))</visible>
         </item>
     </include>
     <include name="LatestPicturesItems2Home">
@@ -4717,6 +4793,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.5.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.5.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.6.Name)]</label>
@@ -4726,6 +4803,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.6.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.6.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.7.Name)]</label>
@@ -4735,6 +4813,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.7.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.7.Name))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MyPicsDBLatest.8.Name)]</label>
@@ -4744,6 +4823,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MyPicsDBLatest.8.Path)]</thumb>
             <visible>Substring(Control.GetLabel(4325),recentpics)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MyPicsDBLatest.8.Name))</visible>
         </item>
     </include>
     <include name="MostPlayedRomsItems2">
@@ -4760,6 +4840,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.1.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.2.Title)]</label>
@@ -4774,6 +4855,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.2.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.3.Title)]</label>
@@ -4788,6 +4870,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.3.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.4.Title)]</label>
@@ -4802,6 +4885,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.4.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.5.Title)]</label>
@@ -4816,6 +4900,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.5.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.6.Title)]</label>
@@ -4830,6 +4915,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.6.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.7.Title)]</label>
@@ -4844,6 +4930,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.7.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(MostPlayedROM.8.Title)]</label>
@@ -4858,6 +4945,7 @@
             <onclick>SetFocus(6014)</onclick>
             <thumb>$INFO[Window(Home).Property(MostPlayedROM.8.Thumb)]</thumb>
             <visible>Substring(Control.GetLabel(4325),mostplayedroms)</visible>
+			<visible>!IsEmpty(Window(Home).Property(MostPlayedROM.8.Title))</visible>
         </item>
     </include>
     <include name="IconPanel1Items2">
@@ -5006,6 +5094,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.1.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.1.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.2.Title)]</label>
@@ -5016,6 +5105,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.2.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.2.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.3.Title)]</label>
@@ -5026,6 +5116,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.3.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.3.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.4.Title)]</label>
@@ -5036,6 +5127,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.4.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.4.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.5.Title)]</label>
@@ -5046,6 +5138,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.5.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.5.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.6.Title)]</label>
@@ -5056,6 +5149,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.6.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.6.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.7.Title)]</label>
@@ -5066,6 +5160,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.7.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.7.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.8.Title)]</label>
@@ -5076,6 +5171,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.8.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.8.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.8.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidget2LeftTV">
@@ -5086,6 +5182,7 @@
             <property name="NavItem">item1.png</property>
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RecommendedEpisode.1.Art(thumb))]</icon>
             <onclick>$INFO[Window(Home).Property(RecommendedEpisode.1.Play)]</onclick>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedEpisode.1.Title))</visible>
             <visible>Substring(Control.GetLabel(4325),featuredtv)</visible>
         </item>
         <item>
@@ -5170,6 +5267,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.1.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.2.Title)]</label>
@@ -5181,6 +5279,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.2.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.3.Title)]</label>
@@ -5192,6 +5291,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.3.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.4.Title)]</label>
@@ -5203,6 +5303,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.4.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.5.Title)]</label>
@@ -5214,6 +5315,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.5.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.6.Title)]</label>
@@ -5225,6 +5327,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.6.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.7.Title)]</label>
@@ -5236,6 +5339,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.7.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomAlbum.8.Title)]</label>
@@ -5247,6 +5351,7 @@
             <thumb>$INFO[Window(Home).Property(RandomAlbum.8.Art(thumb))]</thumb>
             <onclick>PlayList.Clear</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomAlbum.8.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidget2MiddleMovies">
@@ -5314,6 +5419,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.11.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.11.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.1.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.11.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.12.Title)]</label>
@@ -5324,6 +5430,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.12.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.12.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.2.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.12.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.13.Title)]</label>
@@ -5334,6 +5441,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.13.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.13.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.3.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.13.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.14.Title)]</label>
@@ -5344,6 +5452,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.14.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.14.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.4.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.14.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomMovie.15.Title)]</label>
@@ -5354,6 +5463,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomMovie.15.Art(fanart))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomMovie.15.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmovies) + IsEmpty(Window(Home).Property(RecommendedMovie.5.Title))</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomMovie.15.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidget2MiddleTV">
@@ -5365,6 +5475,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.1.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.1.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.2.Title)]</label>
@@ -5374,6 +5485,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.2.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.2.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.3.Title)]</label>
@@ -5383,6 +5495,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.3.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.3.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.4.Title)]</label>
@@ -5392,6 +5505,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.4.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.4.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RandomEpisode.5.Title)]</label>
@@ -5401,6 +5515,7 @@
             <icon fallback="DefaultTVShows.png">$INFO[Window(Home).Property(RandomEpisode.5.Art(tvshow.poster))]</icon>
             <onclick>$INFO[Window(Home).Property(RandomEpisode.5.Play)]</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredtv)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RandomEpisode.5.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidget2MiddleMusic">
@@ -5414,6 +5529,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.1.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.2.Title)]</label>
@@ -5425,6 +5541,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.2.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.3.Title)]</label>
@@ -5436,6 +5553,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.3.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.4.Title)]</label>
@@ -5447,6 +5565,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.4.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(Home).Property(RecommendedAlbum.5.Title)]</label>
@@ -5458,6 +5577,7 @@
             <thumb>$INFO[Window(Home).Property(RecommendedAlbum.5.Art(thumb))]</thumb>
             <onclick>noop</onclick>
             <visible>Substring(Control.GetLabel(4325),featuredmusic)</visible>
+			<visible>!IsEmpty(Window(Home).Property(RecommendedAlbum.5.Title))</visible>
         </item>
     </include>
     <include name="FeaturedWidget2RightMovies">
@@ -6650,6 +6770,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.0.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.0.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.1.title)]</label>
@@ -6658,6 +6779,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.1.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.1.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.2.title)]</label>
@@ -6666,6 +6788,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.2.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.2.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.3.title)]</label>
@@ -6674,6 +6797,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.3.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.3.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.4.title)]</label>
@@ -6682,6 +6806,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.4.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.4.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.5.title)]</label>
@@ -6690,6 +6815,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.5.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.5.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.6.title)]</label>
@@ -6698,6 +6824,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.6.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.6.title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(bigpictures.photo.7.title)]</label>
@@ -6706,6 +6833,7 @@
             <thumb>$INFO[Window(home).Property(bigpictures.photo.7.pic)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),thebigpicture)</visible>
+			<visible>!IsEmpty(Window(Home).Property(bigpictures.photo.7.title))</visible>
         </item>
     </include>
     <include name="NavigationWidget2">
@@ -6721,6 +6849,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.0.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.0.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.1.Title)]</label>
@@ -6728,6 +6857,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.1.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.2.Title)]</label>
@@ -6735,6 +6865,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.2.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.3.Title)]</label>
@@ -6742,6 +6873,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.3.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.4.Title)]</label>
@@ -6749,6 +6881,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.4.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.5.Title)]</label>
@@ -6756,6 +6889,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.5.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.6.Title)]</label>
@@ -6763,6 +6897,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.6.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(XKCD.7.Title)]</label>
@@ -6770,6 +6905,7 @@
             <thumb>$INFO[Window(home).Property(XKCD.7.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),xkcd)</visible>
+			<visible>!IsEmpty(Window(Home).Property(XKCD.7.Title))</visible>
         </item>
     </include>
     <include name="CyanideContent2">
@@ -6778,48 +6914,56 @@
             <thumb>$INFO[Window(home).Property(CyanideHappiness.1.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.1.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.2.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.2.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.2.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.3.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.3.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.3.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.4.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.4.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.4.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.5.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.5.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.5.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.6.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.6.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.6.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.7.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.7.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.7.Title))</visible>
         </item>
         <item>
             <label>$INFO[Window(home).Property(CyanideHappiness.8.Title)]</label>
             <thumb>$INFO[Window(home).Property(CyanideHappiness.8.Image)]</thumb>
             <onclick>SetFocus(6014)</onclick>
             <visible>Substring(Control.GetLabel(4325),cyanide)</visible>
+			<visible>!IsEmpty(Window(Home).Property(CyanideHappiness.8.Title))</visible>
         </item>
     </include>
 </includes>


### PR DESCRIPTION
XBMC 12.0: Git:20130127-fb595f2 (Released final version)
Skin: Aeon Nox v4.0.9. Downloaded through the official repository.

I've just recently reinstalled XBMC Frodo and set everything up with 2 profiles.
It occured to me that when  the Aeon Nox skin is set up to display the Latest Movies widget on the main menu, it at times displays movies from the other profile. This happens when the widget switches to the next movie (in classic mode) and when it displays all movies (standard behavior in all modes except in classic mode, where the user has to press Up to display all the recent movies).

Steps to reproduce:
1. Start from a fresh XBMC installation.
2. Setup 2 new profiles.
3a. Add a few movies to profile 1, might even work with nu movies in profile 1.
(just make sure that the recent movies widget will not fill up with movies from profile 1.)
3b. And of course add a couple of movies to profile 2.
4. Makes sure you've started profile 2 at least once  in your running XBMC instance.
(If you directly start profile 1 it will display the proper list in the widget.
Logging out of profile 1, entering profile 2, and logging back in to profile 1 also works)
5. Log out of profile 2 and log in to profile 1.
6. The latest movie widget will now contain a couple of movies with no name, but with a poster picture and info like the movie description, next to a couple of proper movies from profile 1.

I've attached a screenshot of the bug in action. As you can see, there are a couple of no named items from profile 2, which when selected will show something like the example in the screenshot.

Let me know if somethings still not clear!
And of course a big thank you for the wonderful work all developers and artists put into this skin. It looks absolutely gorgeous.

Edit: Added a second screenshot showing the expected behavior (which occurs when profile 2 has not been logged into in the current XBMC instance). As you can see the no named items are still there, but they simply show no movie info (as they should).

Edit 2: I've setup a fresh portable XBMC installation with only changes that were necessary to easily reproduce the bug.
The portable_data folder is downloadable through: http://goo.gl/2yhqm
Hope this makes it easier to identify the problem!

![screenshot000](https://f.cloud.github.com/assets/3781551/225373/be63147e-85f0-11e2-96a3-24d70d57e698.png)

![screenshot001](https://f.cloud.github.com/assets/3781551/225393/5f0d731a-85f1-11e2-8698-6473f14df4e6.png)
