### PR TITLE
Add condition for German MPAA Ratings to RatingFlagVar

### DIFF
--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -256,10 +256,10 @@
         <value condition="SubString(ListItem.mpaa,UK:12)">BBFC_12_Certificate_UK</value>
         <value condition="SubString(ListItem.mpaa,UK:15)">BBFC_15_Certificate_UK</value>
         <value condition="SubString(ListItem.mpaa,UK:18)">BBFC_18_Certificate_UK</value>
-        <value condition="SubString(ListItem.mpaa,Germany:6)| SubString(ListItem.mpaa,ab 6) | StringCompare(ListItem.mpaa,6) | Substring(ListItem.mpaa,FSK 16) | SubString(ListItem.mpaa,Rated 6)">FSK-6</value>
-        <value condition="SubString(ListItem.mpaa,Germany:12) | SubString(ListItem.mpaa,ab 12) | StringCompare(ListItem.mpaa,12) | Substring(ListItem.mpaa,FSK 12) | SubString(ListItem.mpaa,Rated 12)">FSK-12</value>
-        <value condition="SubString(ListItem.mpaa,Germany:16) | SubString(ListItem.mpaa,ab 16) | StringCompare(ListItem.mpaa,16) | Substring(ListItem.mpaa,FSK 16) | SubString(ListItem.mpaa,Rated 16)">FSK-16</value>
-        <value condition="SubString(ListItem.mpaa,Germany:18) | SubString(ListItem.mpaa,ab 18) | StringCompare(ListItem.mpaa,18) | Substring(ListItem.mpaa,FSK 18) | SubString(ListItem.mpaa,Rated 18)">FSK-18</value>
+        <value condition="SubString(ListItem.mpaa,Germany:6)| SubString(ListItem.mpaa,ab 6) | StringCompare(ListItem.mpaa,6) | SubString(ListItem.mpaa,Rated 6) | SubString(ListItem.mpaa,FSK 6)">FSK-6</value>
+        <value condition="SubString(ListItem.mpaa,Germany:12) | SubString(ListItem.mpaa,ab 12) | StringCompare(ListItem.mpaa,12) | SubString(ListItem.mpaa,Rated 12) | SubString(ListItem.mpaa,FSK 12)">FSK-12</value>
+        <value condition="SubString(ListItem.mpaa,Germany:16) | SubString(ListItem.mpaa,ab 16) | StringCompare(ListItem.mpaa,16) | SubString(ListItem.mpaa,Rated 16) | SubString(ListItem.mpaa,FSK 16)">FSK-16</value>
+        <value condition="SubString(ListItem.mpaa,Germany:18) | SubString(ListItem.mpaa,ab 18) | StringCompare(ListItem.mpaa,18) | SubString(ListItem.mpaa,Rated 18) | SubString(ListItem.mpaa,FSK 18)">FSK-18</value>
         <value condition="SubString(ListItem.mpaa,Germany)|SubString(ListItem.mpaa,FSK)| SubString(ListItem.mpaa,o.A)| SubString(ListItem.mpaa,Rated 0)">FSK-0</value>
         <value condition="SubString(ListItem.mpaa,besorolás alatt)">HU_BA</value>
         <value condition="SubString(ListItem.mpaa,korhatárra való tekintett nélkül megtekintetheto)">HU_KN</value>


### PR DESCRIPTION
Missing flags for MPAAs like "Rated FSK 16"
