### PR TITLE
Cleanup font.xml

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -77,7 +77,6 @@
 			<name>font13_title</name>
 			<filename>RobotoCondensed-Uppercase.ttf</filename>
 			<style>uppercase</style>
-			<style>normal</style>
 			<size>30</size>
 		</font>
 		<font>


### PR DESCRIPTION
Turns out this doesn't fix the font weight issue with the Global Search labels. There are still a few that are bolded by the addon. And this syntax is incorrect, should have been `<style>uppercase normal</style>`.
