### PR TITLE
Unmatching parentheses

### DIFF
--- a/1080i/Includes_LiveBG.xml
+++ b/1080i/Includes_LiveBG.xml
@@ -509,7 +509,7 @@
 	</variable>
 	<variable name="Case3Var">
 		<value condition="!IsEmpty(Container(9031).ListItem(2).Art(tvshow.poster))">$INFO[Container(9031).ListItem(2).Art(tvshow.poster)]</value>
-		<value condition="!IsEmpty(Container(9031).ListItem((2).Art(poster)))">$INFO[Container(9031).ListItem((2).Art(poster)]</value>
+		<value condition="!IsEmpty(Container(9031).ListItem((2).Art(poster)))">$INFO[Container(9031).ListItem(2).Art(poster)]</value>
 		<value>$INFO[Container(9031).ListItem(2).Icon]</value>
 	</variable>
 	<variable name="Case4Var">


### PR DESCRIPTION
Just a little fix because this unclosed parentheses rize an error in log file :

ERROR: unmatched parentheses in Container(9031).ListItem((2).Art(poster)
