### PR TITLE
Fix for at least three subtitle services.

### DIFF
--- a/1080i/DialogSubtitles.xml
+++ b/1080i/DialogSubtitles.xml
@@ -6,7 +6,6 @@
 		<posy>180</posy>
 		<system>1</system>
     </coordinates>
-	<zorder>2</zorder>
     <controls>
 		<control type="group" id="250">
 			<include>dialogeffect</include>


### PR DESCRIPTION
FileBrowser was going behind the DialogSubtitles.
No need of having zorder = 2 in the DialogSubtitles. It would produce the bug on the FileBrowser.
Services are LegendasDivx \ LegendasZone \ Pipocas.
I'll fix the pull request on the gotham branch too.
