### PR TITLE
Add support to more than one playlist infoline

### DIFF
--- a/1080i/custom_1125_InfoLineCustomizer.xml
+++ b/1080i/custom_1125_InfoLineCustomizer.xml
@@ -140,8 +140,18 @@
 					<onclick>Dialog.Close(1125)</onclick>
 				</item>
 				<item>
-					<label>$LOCALIZE[559]</label>
+					<label>$LOCALIZE[31097]</label>
 					<onclick>Skin.SetString(ItemToEdit.InfoLine,9)</onclick>
+					<onclick>Dialog.Close(1125)</onclick>
+				</item>
+				<item>
+					<label>$LOCALIZE[31098]</label>
+					<onclick>Skin.SetString(ItemToEdit.InfoLine,10)</onclick>
+					<onclick>Dialog.Close(1125)</onclick>
+				</item>
+				<item>
+					<label>$LOCALIZE[31099]</label>
+					<onclick>Skin.SetString(ItemToEdit.InfoLine,11)</onclick>
 					<onclick>Dialog.Close(1125)</onclick>
 				</item>
 			</content>

--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -95,6 +95,8 @@
 		<value condition="StringCompare(Container(9000).ListItem.Property(InfoLine),7)">$INFO[Window(Home).Property(MusicVideos.Count),[COLOR grey]$LOCALIZE[20389]:[/COLOR] ]$INFO[Window(Home).Property(MusicVideos.Watched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(MusicVideos.UnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]</value>
 		<value condition="StringCompare(Container(9000).ListItem.Property(InfoLine),8)">$INFO[System.memory(used.percent),[COLOR grey]$LOCALIZE[31309][/COLOR] ]$INFO[System.CPUUsage,[COLOR grey] | $LOCALIZE[13271][/COLOR] ]</value>
 		<value condition="StringCompare(Container(9000).ListItem.Property(InfoLine),9)">$INFO[Window(Home).Property(PlaylistCount),[COLOR grey]$LOCALIZE[20342]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistWatched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistUnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistInProgress),[COLOR grey]  |  $LOCALIZE[575]:[/COLOR] ]</value>
+		<value condition="StringCompare(Container(9000).ListItem.Property(InfoLine),10)">$INFO[Window(Home).Property(PlaylistCount),[COLOR grey]$LOCALIZE[20343]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistEpisodes),[COLOR grey]  |  $LOCALIZE[20360]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistEpisodesUnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]</value>
+		<value condition="StringCompare(Container(9000).ListItem.Property(InfoLine),11)">$INFO[Window(Home).Property(PlaylistCount),[COLOR grey]$LOCALIZE[20389]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistWatched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistUnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistInProgress),[COLOR grey]  |  $LOCALIZE[575]:[/COLOR] ]</value>
 	</variable>
 	<variable name="MusicOSDRepeatButtonVar">
 		<value condition="[!Playlist.IsRepeat + !Playlist.IsRepeatOne] + !Control.HasFocus(707)">osd/buttons/OSDRepeatNF.png</value>
@@ -406,7 +408,9 @@
 		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),6)">$LOCALIZE[31061]</value>
 		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),7)">$LOCALIZE[31085]</value>
 		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),8)">$LOCALIZE[130]</value>
-		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),9)">$LOCALIZE[559]</value>
+		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),9)">$LOCALIZE[31097]</value>
+		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),10)">$LOCALIZE[31098]</value>
+		<value condition="StringCompare(Container(90000).ListItem.Property(InfoLine),11)">$LOCALIZE[31099]</value>
 	</variable>
 	<variable name="BackgroundLabel2Var">
 		<value condition="StringCompare(Container(90000).ListItem.Thumb,1)">$LOCALIZE[31062]</value>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -402,7 +402,19 @@ msgctxt "#31096"
 msgid "Concert locations"
 msgstr ""
 
-#empty strings from id 31096 to 31101
+msgctxt "#31097"
+msgid "Movie playlist statistics"
+msgstr ""
+
+msgctxt "#31098"
+msgid "TV Show playlist statistics"
+msgstr ""
+
+msgctxt "#31099"
+msgid "Musicvideo playlist statistics"
+msgstr ""
+
+#empty strings from id 31100 to 31101
 #Skin Settings labels
 #####################################################################
 


### PR DESCRIPTION
This pull adds 3 different playlist infolines, for tv shows, movies and musicvideo to have right name and info for every category.
It needs this https://github.com/BigNoid/service.library.data.provider/pull/20 to work.
As the other playlist feel free to ask me changes or ignore it if you want to do it in a different way.
