### PR TITLE
Call service.library.data.provider for infoline playlist only if it's actually selected one

### DIFF
--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -29,6 +29,7 @@
 					<texture flipx="true" flipy="true">submenu_end.png</texture>
 				</control>
 				<control type="list" id="43260">
+					<visible>StringCompare(Container(9000).ListItem.Property(InfoLine),9) | StringCompare(Container(9000).ListItem.Property(InfoLine),10) | StringCompare(Container(9000).ListItem.Property(InfoLine),11)</visible>
 					<posx>0</posx>
 					<posy>0</posy>
 					<width>1</width>


### PR DESCRIPTION
Kodi loads content only if the list is visible so i added a visibility check on the list that make the request for playlist infoline to avoid pointless requests.
