### PR TITLE
Fix media menu onright for epg

### DIFF
--- a/1080i/includes.xml
+++ b/1080i/includes.xml
@@ -97,7 +97,8 @@
 		<height>1080</height>
 		<onleft>9050</onleft>
 		<onright>ClearProperty(MediaMenu,Home)</onright>
-		<onright>50</onright>
+		<onright condition="!Window.IsVisible(tvguide)">50</onright>
+		<onright condition="Window.IsVisible(tvguide)">10</onright>
 		<onup>9050</onup>
 		<ondown>9050</ondown>
 		<onback>ClearProperty(MediaMenu,Home)</onback>


### PR DESCRIPTION
When pressing right from the media menu when using the tv guide, it doesn't return focus to the epg grid. This returns focus to the grid.
