### PR TITLE
Add option to hide video ratings in List, LowList and TriPanel

### DIFF
--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -457,6 +457,16 @@
 						<onclick>Skin.ToggleSetting(Enable.SlimList)</onclick>
 						<texturenofocus border="1">separator5.png</texturenofocus>
 					</control>
+					<control type="radiobutton" id="406">
+						<width>1316</width>
+						<height>90</height>
+						<textoffsetx>30</textoffsetx>
+						<font>font15</font>
+						<label>31961</label>
+						<onclick>Skin.ToggleSetting(Enable.HideRatings)</onclick>
+						<selected>Skin.HasSetting(Enable.HideRatings)</selected>
+						<texturenofocus border="1">separator5.png</texturenofocus>
+					</control>
 				</control>
 			</control>
 		</control>

--- a/1080i/View_501_LowList.xml
+++ b/1080i/View_501_LowList.xml
@@ -364,7 +364,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
-						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
+						<visible>!Skin.HasSetting(Enable.HideRatings) | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 					</control>
 					<control type="image">
 						<left>742</left>
@@ -419,7 +419,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
-						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
+						<visible>!Skin.HasSetting(Enable.HideRatings) | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 						<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(501)">Conditional</animation>
 					</control>
 					<control type="image">
@@ -469,7 +469,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
-						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
+						<visible>!Skin.HasSetting(Enable.HideRatings) | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 					</control>
 					<control type="image">
 						<left>742</left>
@@ -550,7 +550,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
-						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
+						<visible>!Skin.HasSetting(Enable.HideRatings) | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 						<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(501)">Conditional</animation>
 					</control>
 					<control type="image">
@@ -745,7 +745,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
-						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
+						<visible>!Skin.HasSetting(Enable.HideRatings) | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 					</control>
 					<control type="image">
 						<left>742</left>
@@ -788,7 +788,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
-						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
+						<visible>!Skin.HasSetting(Enable.HideRatings) | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 						<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(501)">Conditional</animation>
 					</control>
 					<control type="image">

--- a/1080i/View_501_LowList.xml
+++ b/1080i/View_501_LowList.xml
@@ -364,6 +364,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
+						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 					</control>
 					<control type="image">
 						<left>742</left>
@@ -418,6 +419,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
+						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 						<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(501)">Conditional</animation>
 					</control>
 					<control type="image">
@@ -467,6 +469,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
+						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 					</control>
 					<control type="image">
 						<left>742</left>
@@ -547,6 +550,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
+						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 						<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(501)">Conditional</animation>
 					</control>
 					<control type="image">
@@ -741,6 +745,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
+						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 					</control>
 					<control type="image">
 						<left>742</left>
@@ -783,6 +788,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Rating]</label>
+						<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 						<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(501)">Conditional</animation>
 					</control>
 					<control type="image">

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -89,28 +89,28 @@
 							<visible>StringCompare(ListItem.Label2,ListItem.Rating) | StringCompare(ListItem.Label2,ListItem.Year)</visible>
 						</control>
 						<control type="label">
-							<width>1060</width>
-							<height>116</height>
-							<font>font30</font>
-							<align>right</align>
-							<textcolor>grey2</textcolor>
-							<selectedcolor>selected</selectedcolor>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
-							<visible>StringCompare(ListItem.Label2,ListItem.Rating) + [!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
-						</control>
-						<control type="label">
-							<left>5</left>
-							<width>1060</width>
-							<height>116</height>
-							<font>font15</font>
-							<align>right</align>
-							<textcolor>grey2</textcolor>
-							<selectedcolor>selected</selectedcolor>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
-							<visible>!StringCompare(ListItem.Label2,ListItem.Rating)</visible>
-						</control>
+                            <width>1060</width>
+                            <height>116</height>
+                            <font>font30</font>
+                            <align>right</align>
+                            <textcolor>grey2</textcolor>
+                            <selectedcolor>selected</selectedcolor>
+                            <aligny>center</aligny>
+                            <label>$INFO[ListItem.Rating]</label>
+                            <visible>[StringCompare(ListItem.Label2,ListItem.Rating) + !Skin.HasSetting(Enable.HideRatings)] | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
+                        </control>
+                        <control type="label">
+                            <left>5</left>
+                            <width>1060</width>
+                            <height>116</height>
+                            <font>font15</font>
+                            <align>right</align>
+                            <textcolor>grey2</textcolor>
+                            <selectedcolor>selected</selectedcolor>
+                            <aligny>center</aligny>
+                            <label>$VAR[VideoListLabelVar]</label>
+                            <visible>[!StringCompare(ListItem.Label2,ListItem.Rating) | Skin.HasSetting(Enable.HideRatings)] + !StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
+                        </control>
 						<control type="image">
 							<left>1076</left>
 							<top>28</top>
@@ -188,9 +188,9 @@
 							<textcolor>white</textcolor>
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
+							<label>$INFO[ListItem.Rating]</label>
+                            <visible>[StringCompare(ListItem.Label2,ListItem.Rating) + !Skin.HasSetting(Enable.HideRatings)] | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(50)">Conditional</animation>
-							<visible>StringCompare(ListItem.Label2,ListItem.Rating) + [!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
 						</control>
 						<control type="label">
 							<left>5</left>
@@ -201,9 +201,9 @@
 							<textcolor>white</textcolor>
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
+							<label>$VAR[VideoListLabelVar]</label>
+                            <visible>[!StringCompare(ListItem.Label2,ListItem.Rating) | Skin.HasSetting(Enable.HideRatings)] + !StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(50)">Conditional</animation>
-							<visible>!StringCompare(ListItem.Label2,ListItem.Rating)</visible>
 						</control>
 						<control type="image">
 							<left>1076</left>
@@ -974,7 +974,7 @@
 							<textcolor>grey2</textcolor>
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
+							<label>$VAR[VideoListLabelVar]</label>
 						</control>
 						<control type="image">
 							<left>1076</left>
@@ -1053,7 +1053,7 @@
 							<textcolor>white</textcolor>
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label2]</label>
+							<label>$VAR[VideoListLabelVar]</label>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(50)">Conditional</animation>
 						</control>
 						<control type="image">

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -97,7 +97,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label2]</label>
-							<visible>StringCompare(ListItem.Label2,ListItem.Rating)</visible>
+							<visible>StringCompare(ListItem.Label2,ListItem.Rating) + [!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
 						</control>
 						<control type="label">
 							<left>5</left>
@@ -190,7 +190,7 @@
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label2]</label>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(50)">Conditional</animation>
-							<visible>StringCompare(ListItem.Label2,ListItem.Rating)</visible>
+							<visible>StringCompare(ListItem.Label2,ListItem.Rating) + [!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
 						</control>
 						<control type="label">
 							<left>5</left>

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -89,28 +89,28 @@
 							<visible>StringCompare(ListItem.Label2,ListItem.Rating) | StringCompare(ListItem.Label2,ListItem.Year)</visible>
 						</control>
 						<control type="label">
-                            <width>1060</width>
-                            <height>116</height>
-                            <font>font30</font>
-                            <align>right</align>
-                            <textcolor>grey2</textcolor>
-                            <selectedcolor>selected</selectedcolor>
-                            <aligny>center</aligny>
-                            <label>$INFO[ListItem.Rating]</label>
-                            <visible>[StringCompare(ListItem.Label2,ListItem.Rating) + !Skin.HasSetting(Enable.HideRatings)] | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
-                        </control>
-                        <control type="label">
-                            <left>5</left>
-                            <width>1060</width>
-                            <height>116</height>
-                            <font>font15</font>
-                            <align>right</align>
-                            <textcolor>grey2</textcolor>
-                            <selectedcolor>selected</selectedcolor>
-                            <aligny>center</aligny>
-                            <label>$VAR[VideoListLabelVar]</label>
-                            <visible>[!StringCompare(ListItem.Label2,ListItem.Rating) | Skin.HasSetting(Enable.HideRatings)] + !StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
-                        </control>
+							<width>1060</width>
+							<height>116</height>
+							<font>font30</font>
+							<align>right</align>
+							<textcolor>grey2</textcolor>
+							<selectedcolor>selected</selectedcolor>
+							<aligny>center</aligny>
+							<label>$INFO[ListItem.Rating]</label>
+							<visible>[StringCompare(ListItem.Label2,ListItem.Rating) + !Skin.HasSetting(Enable.HideRatings)] | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
+						</control>
+						<control type="label">
+							<left>5</left>
+							<width>1060</width>
+							<height>116</height>
+							<font>font15</font>
+							<align>right</align>
+							<textcolor>grey2</textcolor>
+							<selectedcolor>selected</selectedcolor>
+							<aligny>center</aligny>
+							<label>$VAR[VideoListLabelVar]</label>
+							<visible>[!StringCompare(ListItem.Label2,ListItem.Rating) | Skin.HasSetting(Enable.HideRatings)] + !StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
+						</control>
 						<control type="image">
 							<left>1076</left>
 							<top>28</top>
@@ -189,7 +189,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
-                            <visible>[StringCompare(ListItem.Label2,ListItem.Rating) + !Skin.HasSetting(Enable.HideRatings)] | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
+							<visible>[StringCompare(ListItem.Label2,ListItem.Rating) + !Skin.HasSetting(Enable.HideRatings)] | StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(50)">Conditional</animation>
 						</control>
 						<control type="label">
@@ -202,7 +202,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$VAR[VideoListLabelVar]</label>
-                            <visible>[!StringCompare(ListItem.Label2,ListItem.Rating) | Skin.HasSetting(Enable.HideRatings)] + !StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
+							<visible>[!StringCompare(ListItem.Label2,ListItem.Rating) | Skin.HasSetting(Enable.HideRatings)] + !StringCompare(Container.SortMethod,$LOCALIZE[563])</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(50)">Conditional</animation>
 						</control>
 						<control type="image">

--- a/1080i/View_55_TriPanel.xml
+++ b/1080i/View_55_TriPanel.xml
@@ -227,7 +227,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label2]</label>
-							<visible>!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])</visible>
+							<visible>!Skin.HasSetting(Enable.HideRatings) | [StringCompare(ListItem.Label2, ListItem.Rating) + StringCompare(Container.SortMethod,$LOCALIZE[563])]</visible>
 						</control>
 						<control type="image">
 							<left>742</left>
@@ -282,7 +282,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label2]</label>
-							<visible>!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])</visible>
+							<visible>!Skin.HasSetting(Enable.HideRatings) | [StringCompare(ListItem.Label2, ListItem.Rating) + StringCompare(Container.SortMethod,$LOCALIZE[563])]</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(55)">Conditional</animation>
 						</control>
 						<control type="image">

--- a/1080i/View_55_TriPanel.xml
+++ b/1080i/View_55_TriPanel.xml
@@ -227,6 +227,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label2]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])</visible>
 						</control>
 						<control type="image">
 							<left>742</left>
@@ -281,6 +282,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label2]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings) | !StringCompare(Container.SortMethod,$LOCALIZE[556])</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(55)">Conditional</animation>
 						</control>
 						<control type="image">
@@ -330,6 +332,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 						</control>
 						<control type="image">
 							<left>742</left>
@@ -410,6 +413,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(55)">Conditional</animation>
 						</control>
 						<control type="image">
@@ -473,6 +477,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 						</control>
 						<control type="image">
 							<left>742</left>
@@ -515,6 +520,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(55)">Conditional</animation>
 						</control>
 						<control type="image">
@@ -1252,6 +1258,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 						</control>
 					</itemlayout>
 					<focusedlayout height="70" width="806">
@@ -1297,6 +1304,7 @@
 							<selectedcolor>selected</selectedcolor>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Rating]</label>
+							<visible>!Skin.HasSetting(Enable.HideRatings)</visible>
 							<animation effect="fade" start="100" end="70" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(55)">Conditional</animation>
 						</control>
 					</focusedlayout>

--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -107,6 +107,10 @@
 		<value condition="Playlist.IsRepeat+ Control.HasFocus(707)">osd/buttons/OSDRepeatAllFO.png</value>
 	</variable>
 	<!--  List Label Vars -->
+	<variable name="VideoListLabelVar">
+        <value condition="Skin.HasSetting(Enable.HideRatings) + StringCompare(ListItem.Label2,ListItem.Rating) + !StringCompare(Container.SortMethod,$LOCALIZE[563])">$INFO[ListItem.Year]</value>
+        <value>$INFO[ListItem.Label2]</value>
+    </variable>
 	<variable name="VideoListLabel2Var">
 		<value condition="Container.Content(episodes)">$INFO[ListItem.Premiered]</value>
 		<value>$INFO[ListItem.Genre]</value>

--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -369,6 +369,7 @@
 		<value condition="Control.HasFocus(403)">$LOCALIZE[31916]</value>
 		<value condition="Control.HasFocus(404)">$LOCALIZE[31944]</value>
 		<value condition="Control.HasFocus(405)">$LOCALIZE[31945]</value>
+		<value condition="Control.HasFocus(406)">$LOCALIZE[31962]</value>
 		<value condition="Control.HasFocus(90000) + IsEmpty(Container(90000).ListItem.Property(Path))">$LOCALIZE[31923]</value>
 		<value condition="Control.HasFocus(90012)">$LOCALIZE[31925]</value>
 		<value condition="Control.HasFocus(90013) | Control.HasFocus(90021)">$LOCALIZE[31926]</value>

--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -799,3 +799,11 @@ msgstr "SYSTEM"
 msgctxt "#31960"
 msgid "CONCERTS"
 msgstr "CONCERTS"
+
+msgctxt "#31961"
+msgid "Hide ratings in list views"
+msgstr "Hide ratings in list views"
+
+msgctxt "#31962"
+msgid "This toggles the visibility of ratings in views of type List, LowList and TriPanel, except if sorted by rating."
+msgstr "This toggles the visibility of ratings in views of type List, LowList and TriPanel, except if sorted by rating."

--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -799,11 +799,3 @@ msgstr "SYSTEM"
 msgctxt "#31960"
 msgid "CONCERTS"
 msgstr "CONCERTS"
-
-msgctxt "#31961"
-msgid "Hide ratings in list views"
-msgstr "Hide ratings in list views"
-
-msgctxt "#31962"
-msgid "This toggles the visibility of ratings in views of type List, LowList and TriPanel, except if sorted by rating."
-msgstr "This toggles the visibility of ratings in views of type List, LowList and TriPanel, except if sorted by rating."

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -850,3 +850,11 @@ msgstr ""
 msgctxt "#31960"
 msgid "CONCERTS"
 msgstr ""
+
+msgctxt "#31961"
+msgid "Hide ratings in list views"
+msgstr ""
+
+msgctxt "#31962"
+msgid "This toggles the visibility of ratings in views of type List, LowList and TriPanel, except if sorted by rating."
+msgstr ""

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -779,3 +779,11 @@ msgstr "SYSTEM"
 msgctxt "#31960"
 msgid "CONCERTS"
 msgstr "KONZERTE"
+
+msgctxt "#31961"
+msgid "Hide ratings in list views"
+msgstr "Bewertungen in Listen ausblenden"
+
+msgctxt "#31962"
+msgid "This toggles the visibility of ratings in views of type List, LowList and TriPanel, except if sorted by rating."
+msgstr "Blendet Bewertungen von Videos in den Ansichten Liste, LowList und TriPanel aus, es sei denn, es wird nach Bewertung sortiert."


### PR DESCRIPTION
I just had the pleasure of testing this marvelous skin for the first time the other day. While having my movie snob friends over, however, it became abundantly clear I needed an option to disable the display of movie ratings altogether. Helps keeping an open mind. 

Anyway, this PR introduces the possibility to toggle ratings globally for views of type List, LowList and TriPanel. Ratings are displayed regardless of the setting, if the list is sorted by them. 