### PR TITLE
Fix playlist button in music OSD

### DIFF
--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -31,13 +31,13 @@
 				<onleft>202</onleft>
 				<onright>202</onright>
 				<control type="button" id="700">
-					<textoffsety>60</textoffsety>
 					<texturefocus>osd/buttons/OSDPlaylistFO.png</texturefocus>
 					<texturenofocus>osd/buttons/OSDPlaylistNF.png</texturenofocus>
 					<label>-</label>
 					<width>100</width>
 					<height>100</height>
 					<font>-</font>
+					<onclick>Close</onclick>
 					<onclick>ActivateWindow(MusicPlaylist)</onclick>
 				</control>
 				<control type="button" id="500">


### PR DESCRIPTION
This fixes the playlist button in the music OSD so that the music viz closes to display the playlist. Assumed the textoffset is not needed, please disregard if it is.