### PR TITLE
Fix hidden date in Next Aired

### DIFF
--- a/1080i/script-NextAired-TVGuide.xml
+++ b/1080i/script-NextAired-TVGuide.xml
@@ -48,8 +48,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>
@@ -73,8 +71,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>
@@ -114,8 +110,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>
@@ -138,8 +132,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>

--- a/1080i/script-NextAired-TVGuide2.xml
+++ b/1080i/script-NextAired-TVGuide2.xml
@@ -56,8 +56,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>
@@ -81,8 +79,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>
@@ -121,8 +117,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>356</left>
-							<top>0</top>
 							<width>356</width>
 							<height>90</height>
 							<font>font15</font>

--- a/21x9/script-NextAired-TVGuide.xml
+++ b/21x9/script-NextAired-TVGuide.xml
@@ -48,8 +48,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>
@@ -73,8 +71,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>
@@ -114,8 +110,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>
@@ -138,8 +132,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>

--- a/21x9/script-NextAired-TVGuide2.xml
+++ b/21x9/script-NextAired-TVGuide2.xml
@@ -56,8 +56,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>
@@ -81,8 +79,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>
@@ -121,8 +117,6 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>576</left>
-							<top>0</top>
 							<width>576</width>
 							<height>90</height>
 							<font>font15</font>


### PR DESCRIPTION
This fixes the label2 dates in the Next Aired window. I finally properly cloned the repo rather just submitting patches through the browser, hope this shows up correctly.