### PR TITLE
Some fixes and Jarvis additions

### DIFF
--- a/1080i/DialogAddonInfo.xml
+++ b/1080i/DialogAddonInfo.xml
@@ -45,6 +45,14 @@
 						<align>left</align>
 						<font>font15</font>
 					</control>
+					<control type="radiobutton" id="13">
+						<description>Auto Update Addon button</description>
+						<width>356</width>
+						<height>68.57</height>
+						<label>21340</label>
+						<align>left</align>
+						<font>font15</font>
+					</control>
 					<control type="button" id="12">
 						<description>Launch Addon button</description>
 						<width>356</width>
@@ -66,14 +74,6 @@
 						<width>356</width>
 						<height>68.57</height>
 						<label>24021</label>
-						<align>left</align>
-						<font>font15</font>
-					</control>
-					<control type="button" id="11">
-						<description>Rollback button</description>
-						<width>356</width>
-						<height>68.57</height>
-						<label>24048</label>
 						<align>left</align>
 						<font>font15</font>
 					</control>

--- a/1080i/Includes_LiveTV.xml
+++ b/1080i/Includes_LiveTV.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="FullScreenInfoBarLiveTV">
 		<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
@@ -27,7 +28,7 @@
 				<texture border="0" colordiffuse="white">new_pvr/osd_line_white.png</texture>
 			</control>
 		</control>
-		
+
 		<!-- Channel logo -->
 		<control type="group" id="1">
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
@@ -75,7 +76,7 @@
 				<label>$INFO[VideoPlayer.ChannelName]</label>
 				<scroll>true</scroll>
 			</control>
-			
+
 			<control type="label" id="1">
 				<left>1370</left>
 				<top>808</top>
@@ -144,7 +145,7 @@
 				</control>
 			</control>
 		</control>
-		
+
 		<!-- Middle Info (Start\End times, Current\Next EPG, Progress-bar, Recording) -->
 		<control type="group" id="1">
 			<visible>VideoPlayer.HasEpg</visible>
@@ -247,7 +248,7 @@
 				<texturebg border="3,0,3,0" colordiffuse="grey3">new_pvr/texturebg_white.png</texturebg>
 			</control>
 		</control>
-		
+
 		<!-- Bottom right Info (Stream status, SNR & Signal, Time-shift) -->
 		<control type="group" id="1">
 			<control type="group">
@@ -287,7 +288,7 @@
 				</control>
 			</control>
 			<!-- Tuner info -->
-			<control type="group"> 
+			<control type="group">
 				<left>1460</left>
 				<top>1017</top>
 				<width>300</width>
@@ -383,7 +384,7 @@
 				</control>
 			</control>
 		</control>
-		
+
 		<!-- Media flags -->
 		<control type="group" id="1">
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
@@ -398,7 +399,7 @@
 				<aspectratio align="center">keep</aspectratio>
 				<texture colordiffuse="grey">$INFO[VideoPlayer.VideoAspect,new_pvr/flags/aspectratio/,.png]</texture>
 			</control>
-			
+
 			<control type="image" id="1">
 				<left>85</left>
 				<top>-20</top>
@@ -415,7 +416,7 @@
 				<aspectratio align="center">keep</aspectratio>
 				<texture colordiffuse="grey">$INFO[VideoPlayer.VideoCodec,new_pvr/flags/videocodec/,.png]</texture>
 			</control>
-			
+
 			<control type="image" id="1">
 				<left>85</left>
 				<top>40</top>
@@ -433,7 +434,7 @@
 				<texture colordiffuse="grey">$INFO[VideoPlayer.AudioChannels,new_pvr/flags/audiochannels/,ch.png]</texture>
 			</control>
 		</control>
-		
+
 		<!-- Encryption -->
 		<control type="group" id="1">
 			<left>65</left>
@@ -637,7 +638,7 @@
 				<aspectratio>keep</aspectratio>
 			</control>
 		</control>
-		
+
 		<!-- Top Info (ChannelNr, Name, Date, Time) -->
 		<control type="group" id="1">
 			<top>18</top>
@@ -757,7 +758,7 @@
 				<label>[B]$INFO[System.Time(hh:mm xx)][/B]</label>
 			</control>
 		</control>
-		
+
 		<!-- Middle Info (Start\End times, Current\Next EPG, Progress-bar, Recording) -->
 		<control type="group" id="1">
 			<visible>VideoPlayer.HasEpg</visible>
@@ -871,9 +872,9 @@
 				<visible>!IsEmpty(VideoPlayer.Title)</visible>
 				<visible>![VideoPlayer.Content(LiveTV) + Player.Recording]</visible>
 			</control>
-		</control>	
+		</control>
 	</include>
-	
+
 	<variable name="GuideChannelListTypeOptionsClickVar">
 		<value condition="IsEmpty(Skin.String(LiveTV.EpgViewChannels))">Skin.SetString(LiveTV.EpgViewChannels,1)</value>
 		<value condition="StringCompare(Skin.String(LiveTV.EpgViewChannels),1)">Skin.SetString(LiveTV.EpgViewChannels,2)</value>
@@ -884,7 +885,7 @@
 		<value condition="StringCompare(Skin.String(LiveTV.EpgViewChannels),2)">Name &amp; Icon</value>
 		<value>Name only</value>
 	</variable>
-	
+
 	<variable name="GuideTimelineViewOptionsClickVar">
 		<value condition="IsEmpty(Skin.String(LiveTV.EpgViewType))">Skin.SetString(LiveTV.EpgViewType,1)</value>
 		<value condition="StringCompare(Skin.String(LiveTV.EpgViewType),1)">Skin.SetString(LiveTV.EpgViewType,2)</value>
@@ -895,7 +896,7 @@
 		<value condition="StringCompare(Skin.String(LiveTV.EpgViewType),2)">Large</value>
 		<value>Standard</value>
 	</variable>
-	
+
 	<variable name="LiveTvInfobarTypeOptionsClickVar">
 		<value condition="IsEmpty(Skin.String(LiveTV.InfobarType))">Skin.SetString(LiveTV.InfobarType,1)</value>
 		<value condition="StringCompare(Skin.String(LiveTV.InfobarType),1)">Skin.Reset(LiveTV.InfobarType)</value>
@@ -906,7 +907,7 @@
 		<!-- <value condition="StringCompare(Skin.String(LiveTV.InfobarType),2)">Faded</value> -->
 		<value>Standard</value>
 	</variable>
-	
+
 	<include name="SystemCenterPanel">
 		<control type="image">
 			<left>50</left>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -25,6 +25,7 @@
 			<pauseatend>7000</pauseatend>
 			<font>font10</font>
 			<textcolor>white</textcolor>
+			<randomize>true</randomize>
 			<label>$INFO[ListItem.Art(extrafanart1)]</label>
 			<label>$INFO[ListItem.Art(extrafanart2)]</label>
 			<label>$INFO[ListItem.Art(extrafanart3)]</label>

--- a/1080i/MyWeather.xml
+++ b/1080i/MyWeather.xml
@@ -2005,6 +2005,7 @@
 					<include>ButtonCommonValues</include>
 				</control>
 				<control type="button" id="2001">
+					<include>ButtonCommonValues</include>
 					<label>$LOCALIZE[19190]</label>
 					<onclick>Skin.SetAddon(WeatherFanartDir,kodi.resource.images)</onclick>
 				</control>

--- a/1080i/View_501_LowList.xml
+++ b/1080i/View_501_LowList.xml
@@ -868,7 +868,7 @@
 					<label>[COLOR labelheader]$LOCALIZE[515]:[/COLOR][CR]$INFO[ListItem.Genre]</label>
 					<width>650</width>
 					<include>ShowCaseInfoPanelButtonsValues</include>
-					<visible>!IsEmpty(ListItem.Genre)</visible>
+					<visible>!IsEmpty(ListItem.Genre) + !Container.Content(artists)</visible>
 				</control>
 				<control type="button">
 					<label>[COLOR labelheader]$LOCALIZE[180]:[/COLOR][CR]$INFO[ListItem.Duration]</label>

--- a/1080i/View_51_InfoWall.xml
+++ b/1080i/View_51_InfoWall.xml
@@ -350,7 +350,7 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<left>104</left>
+				<left>154</left>
 				<top>179</top>
 				<width>14</width>
 				<height>900</height>

--- a/1080i/includes.xml
+++ b/1080i/includes.xml
@@ -192,6 +192,7 @@
 					<usealttexture>Container.SortDirection(Ascending)</usealttexture>
 				</control>
 				<control type="button" id="2001">
+					<include>ButtonCommonValues</include>
 					<label>$LOCALIZE[19190]</label>
 					<onclick>ActivateWindow(1128)</onclick>
 				</control>
@@ -254,13 +255,12 @@
 					<disabledcolor>themecolor</disabledcolor>
 				</control>
 				<control type="button" id="330">
-                    <description>Settings</description>
-                    <textwidth>352</textwidth>
-                    <include>ButtonCommonValues</include>
-                    <label>Skin-mod settings</label>
-					<onclick>XBMC.ActivateWindow(1150)</onclick>
-                </control>
-				
+					<description>Settings</description>
+					<textwidth>352</textwidth>
+					<include>ButtonCommonValues</include>
+					<label>$LOCALIZE[31127]</label>
+					<onclick>ActivateWindow(1150)</onclick>
+				</control>
 			</control>
 		</control>
 	</include>
@@ -289,6 +289,7 @@
 			<aligny>center</aligny>
 		</control>
 		<control type="button" id="2001">
+			<include>ButtonCommonValues</include>
 			<label>$LOCALIZE[19190]</label>
 			<onclick>ActivateWindow(1128)</onclick>
 		</control>

--- a/21x9/DialogAddonInfo.xml
+++ b/21x9/DialogAddonInfo.xml
@@ -58,6 +58,14 @@
 						<align>left</align>
 						<font>font15</font>
 					</control>
+					<control type="radiobutton" id="13">
+						<description>Auto Update Addon button</description>
+						<width>356</width>
+						<height>68.57</height>
+						<label>21340</label>
+						<align>left</align>
+						<font>font15</font>
+					</control>
 					<control type="button" id="12">
 						<description>Launch Addon button</description>
 						<width>356</width>
@@ -79,14 +87,6 @@
 						<width>356</width>
 						<height>68.57</height>
 						<label>24021</label>
-						<align>left</align>
-						<font>font15</font>
-					</control>
-					<control type="button" id="11">
-						<description>Rollback button</description>
-						<width>356</width>
-						<height>68.57</height>
-						<label>24048</label>
 						<align>left</align>
 						<font>font15</font>
 					</control>

--- a/21x9/MyWeather.xml
+++ b/21x9/MyWeather.xml
@@ -2005,6 +2005,7 @@
 					<include>ButtonCommonValues</include>
 				</control>
 				<control type="button" id="2001">
+					<include>ButtonCommonValues</include>
 					<label>$LOCALIZE[19190]</label>
 					<onclick>Skin.SetAddon(WeatherFanartDir,kodi.resource.images)</onclick>
 				</control>

--- a/21x9/includes.xml
+++ b/21x9/includes.xml
@@ -134,7 +134,6 @@
 		<control type="button" id="2001">
 			<include>ButtonCommonValues</include>
 			<label>$LOCALIZE[19190]</label>
-			<include>ButtonCommonValues</include>
 			<onclick>ActivateWindow(1128)</onclick>
 		</control>
 	</include>
@@ -194,6 +193,7 @@
 					<usealttexture>Container.SortDirection(Ascending)</usealttexture>
 				</control>
 				<control type="button" id="2001">
+					<include>ButtonCommonValues</include>
 					<label>$LOCALIZE[19190]</label>
 					<onclick>ActivateWindow(1128)</onclick>
 				</control>
@@ -289,6 +289,7 @@
 			<aligny>center</aligny>
 		</control>
 		<control type="button" id="2001">
+			<include>ButtonCommonValues</include>
 			<label>$LOCALIZE[19190]</label>
 			<onclick>ActivateWindow(1128)</onclick>
 		</control>


### PR DESCRIPTION
[DialogAddonInfo] Remove Rollback button + Add Auto-update radiobutton
[LowList] Fix double artist genre
[InfoWall] Music include scrollbar alignment fix
[Includes_LiveTV] Add XML declaration
Add missing ButtonCommonValues includes
Add randomize true tag for extrafanart fadelabel

Remove and add buttons to DialogAddonInfo [here](http://forum.kodi.tv/showthread.php?tid=231270&pid=2136968#pid2136968) and [here](http://forum.kodi.tv/showthread.php?tid=231270&pid=2161413#pid2161413)

I noticed double artist genre in Lowlist, it may be a Jarvis issue since both the regular ListItem.Genre and ListItem.Property(Artist_Genre) are displayed it appears twice when using latest Jarvis nightlies.

InfoWall scrollbar for the music section was not left enough, off about 50 pixels.

Added some missing ButtonCommonValues includes from some Background buttons 