### PR TITLE
Fix sidemenu onright of TVGuide2.xml

### DIFF
--- a/1080i/script-NextAired-TVGuide2.xml
+++ b/1080i/script-NextAired-TVGuide2.xml
@@ -445,7 +445,7 @@
 					<onback>2000</onback>
 					<include>ButtonCommonValues</include>
 					<label>5</label>
-					<onright>2000</onright>
+					<onright>9000</onright>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
onright for the Next Aired TV Guide 2 settings button (8) was set to an ID not  in the xml so it doesn't put focus on the guide causing the need to exit and re-enter. A slight annoyance when I accidentally open the side menu when navigating too quickly :smiley: