### PR TITLE
EPG Item Background Missing on Standard Timeline View

### DIFF
--- a/1080i/Includes_LiveTV_Views.xml
+++ b/1080i/Includes_LiveTV_Views.xml
@@ -279,7 +279,7 @@
 				<texture border="1">separator2.png</texture>
 			</control>
 			<control type="group">
-				<visible>!IsEmpty(ListItem.Icon)</visible>
+		    <visible>Control.IsVisible(10) + !IsEmpty(ListItem.Icon)</visible>	
 				<posx>83</posx>
 				<posy>617</posy>
 				<control type="image">
@@ -293,6 +293,7 @@
 				</control>
 			</control>
 			<control type="group">
+   		  <visible>Control.IsVisible(10)</visible>
 				<posx>522</posx>
 				<posy>617</posy>
 				<control type="label">

--- a/1080i/Includes_LiveTV_Views.xml
+++ b/1080i/Includes_LiveTV_Views.xml
@@ -165,6 +165,12 @@
 					</control>
 				</focusedchannellayout>
 				<itemlayout height="60" width="120">
+				<control type="image" id="1">
+						<width>120</width>
+						<height>60</height>
+						<aspectratio>stretch</aspectratio>
+						<texture border="0" colordiffuse="33FFFFFF">new_pvr/epg-item.png</texture>
+					</control>
 					<control type="image" id="1">
 						<width>120</width>
 						<height>60</height>


### PR DESCRIPTION
The EPG background texture for the standard timeline view was missing. Re-added it. Fixed double rendering of channel logo and outline for IDs 11, 12, 13.