### PR TITLE
Missing bracket

### DIFF
--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -121,13 +121,13 @@
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),1)">$INFO[Window(Home).Property(Movies.Count),[COLOR grey]$LOCALIZE[20342]:[/COLOR] ]$INFO[Window(Home).Property(Movies.Watched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(Movies.UnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),2)">$INFO[Window(Home).Property(TVShows.Count),[COLOR grey]$LOCALIZE[20343]:[/COLOR] ]$INFO[Window(Home).Property(Episodes.Count),[COLOR grey]  |  $LOCALIZE[20360]:[/COLOR] ]$INFO[Window(Home).Property(Episodes.UnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),3)">$INFO[Window(Home).Property(Music.ArtistsCount),[COLOR grey]$LOCALIZE[133]:[/COLOR] ]$INFO[Window(Home).Property(Music.AlbumsCount),[COLOR grey]  |  $LOCALIZE[132]:[/COLOR] ]$INFO[Window(Home).Property(Music.SongsCount),[COLOR grey]  |  $LOCALIZE[134]:[/COLOR] ]</value>
-		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),4) + PVR.IsRecording">$LOCALIZE[19158] $INFO[PVR.NowRecordingDateTime, [COLOR=white]] | [COLOR=FF48D1CC]$INFO[PVR.NowRecordingTitle][/COLOR] [COLOR=white]($INFO[PVR.NowRecordingChannel, ])[/COLOR]</value>
-		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),4) + PVR.HasNonRecordingTimer">$LOCALIZE[19157] $INFO[PVR.NextRecordingDateTime, [COLOR=white], [/COLOR]] | $INFO[PVR.NextRecordingTitle, [COLOR=white],[/COLOR]$INFO[PVR.NextRecordingChannel, - [COLOR=white],[/COLOR]]</value>
+		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),4) + PVR.IsRecording">$LOCALIZE[19158] $INFO[PVR.NowRecordingDateTime,[COLOR=white],]  |  [/COLOR][COLOR=FF48D1CC]$INFO[PVR.NowRecordingTitle][/COLOR][COLOR=white]$INFO[PVR.NowRecordingChannel, (,)][/COLOR]</value>
+		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),4) + PVR.HasNonRecordingTimer">$LOCALIZE[19157] $INFO[PVR.NextRecordingDateTime,[COLOR=white],]  |  [/COLOR]$INFO[PVR.NextRecordingTitle,[COLOR=white],[/COLOR]]$INFO[PVR.NextRecordingChannel,[COLOR=white] - ,[/COLOR]]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),4)">$INFO[Pvr.BackendChannels,[COLOR grey]$LOCALIZE[19019]:[/COLOR] ]$INFO[Pvr.BackendRecordings,[COLOR grey]  |  $LOCALIZE[19163]:[/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),5)">$INFO[Weather.Location,[COLOR grey],:[/COLOR] ]$INFO[Weather.Conditions]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),6)">$INFO[Window(Home).Property(RandomAddon.Count),[COLOR grey]$LOCALIZE[20161] $LOCALIZE[24001]: [/COLOR],[COLOR grey]  |  [/COLOR]]$INFO[Window(home).Property(favourite.count), [COLOR grey]$LOCALIZE[1036]:[/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),7)">$INFO[Window(Home).Property(MusicVideos.Count),[COLOR grey]$LOCALIZE[20389]:[/COLOR] ]$INFO[Window(Home).Property(MusicVideos.Watched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(MusicVideos.UnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]</value>
-		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),8)">$INFO[System.memory(used.percent),[COLOR grey]$LOCALIZE[31309][/COLOR] ]$INFO[System.CPUUsage,[COLOR grey] | $LOCALIZE[13271][/COLOR] ]</value>
+		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),8)">$INFO[System.memory(used.percent),[COLOR grey]$LOCALIZE[31309][/COLOR] ]$INFO[System.CPUUsage,[COLOR grey]  |  $LOCALIZE[13271][/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),9)">$INFO[Window(Home).Property(PlaylistCount),[COLOR grey]$LOCALIZE[20342]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistWatched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistUnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistInProgress),[COLOR grey]  |  $LOCALIZE[575]:[/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),10)">$INFO[Window(Home).Property(PlaylistTVShowCount),[COLOR grey]$LOCALIZE[20343]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistEpisodes),[COLOR grey]  |  $LOCALIZE[20360]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistEpisodesUnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]</value>
 		<value condition="String.IsEqual(Container(9000).ListItem.Property(InfoLine),11)">$INFO[Window(Home).Property(PlaylistCount),[COLOR grey]$LOCALIZE[20389]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistWatched),[COLOR grey]  |  $LOCALIZE[16102]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistUnWatched),[COLOR grey]  |  $LOCALIZE[16101]:[/COLOR] ]$INFO[Window(Home).Property(PlaylistInProgress),[COLOR grey]  |  $LOCALIZE[575]:[/COLOR] ]</value>
@@ -613,7 +613,7 @@
 		<value condition="Integer.IsGreater(VideoPlayer.AudioChannels,1)">2.0</value>
 		<value condition="Integer.IsGreater(VideoPlayer.AudioChannels,0)">1.0</value>
 	</variable>
-	<!-- 
+	<!--
 	     Studio flags
 	 -->
 	<variable name="StudioFlagColorVar">
@@ -658,7 +658,7 @@
 		<value condition="Container.Content(movies) + String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.Tagline,[COLOR labelheader],[/COLOR] - ]$INFO[ListItem.Plot]</value>
 		<value>$INFO[ListItem.Plot]</value>
 	</variable>
-	<!-- 
+	<!--
 	     DialogVideoInfo
 	 -->
 	<variable name="VideoInfoDetailsLabelVar">
@@ -679,7 +679,7 @@
 		<value condition="!Integer.IsGreater(ListItem.Episode,9)">$INFO[ListItem.Season,S]$INFO[ListItem.Episode,E0]</value>
 		<value>$INFO[ListItem.Season,S]$INFO[ListItem.Episode,E]</value>
 	</variable>
-	<!-- 
+	<!--
 	     DialogMusicInfo
 	 -->
 	<variable name="MusicInfoHeader">
@@ -687,7 +687,7 @@
 		<value condition="Container.Content(Albums)">$LOCALIZE[10523]</value>
 		<value condition="Container.Content(Songs)">$LOCALIZE[658]</value>
 	</variable>
-	<!-- 
+	<!--
 	     Extendend Info
 	 -->
 	<variable name="ExtendedInfo.FavLabelVar">
@@ -716,7 +716,7 @@
 		<value condition="ControlGroup(9001).HasFocus(650)">$ADDON[script.extendedinfo 32123]$INFO[Container(650).NumItems, [COLOR grey3](,)[/COLOR]]</value>
 		<value condition="ControlGroup(9001).HasFocus(750)">$LOCALIZE[20445]$INFO[Container(750).NumItems, [COLOR grey3](,)[/COLOR]]</value>
 	</variable>
-	<!-- 
+	<!--
 	     Select dialog
 	 -->
 	<variable name="DialogSelectLabel2Var">
@@ -749,7 +749,7 @@
 		<value condition="Control.HasFocus(21)">$INFO[Container(21).ListItem.Property(Description)]</value>
 		<value condition="Control.HasFocus(9000)">$INFO[Container(9000).ListItem.Label2]</value>
 		<value>$LOCALIZE[15020]</value>
-	</variable>	
+	</variable>
 	<variable name="503.InfoPanelTextboxVar">
 		<value condition="Container.Content(movies)">$INFO[ListItem.PlotOutline]</value>
 		<value condition="Container.Content(tvshows)">$INFO[ListItem.Plot]</value>


### PR DESCRIPTION
Add parenthesis surrounding NowRecordingChannel using prefix/postfix, missing closing bracket after color formatting for pvr infoline and add double spacing before/after pipe symbol for system infoline . Other stuff is just whitespace auto deleted when saving.

PVR.HasNonRecordingTimer is the only InfoLine that has "-" in it so I kept it white like the pipe symbol.