### PR TITLE
LibrarySettings > MediaSettings + Wall view only show InfoPanel when focused

### DIFF
--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -91,9 +91,9 @@
 						<icon>-</icon>
 					</item>
 					<item id="4">
-						<label>14202</label>
+						<label>14211</label>
 						<property name="description">31415</property>
-						<onclick>ActivateWindow(LibrarySettings)</onclick>
+						<onclick>ActivateWindow(MediaSettings)</onclick>
 						<icon>-</icon>
 					</item>
 					<item id="11">

--- a/1080i/View_503_Wall.xml
+++ b/1080i/View_503_Wall.xml
@@ -198,7 +198,7 @@
 				<top>100</top>
 				<visible>!ListItem.IsParentFolder</visible>
 				<visible>[Container.Content(movies) | Container.Content(tvshows)]</visible>
-				<visible>Skin.HasSetting(503.InfoPanel) + System.IdleTime(1)</visible>
+				<visible>Skin.HasSetting(503.InfoPanel) + Control.HasFocus(503) + System.IdleTime(1)</visible>
 				<animation effect="fade" time="100" delay="200">Visible</animation>
 				<animation effect="slide" end="0,460" time="300" tween="cubic" easing="inout" condition="Container(503).Row(1)">Conditional</animation>
 				<animation effect="slide" end="320,0" time="300" tween="cubic" easing="inout" condition="Container(503).Column(3)">Conditional</animation>

--- a/21x9/View_503_Wall.xml
+++ b/21x9/View_503_Wall.xml
@@ -198,7 +198,7 @@
 				<top>100</top>
 				<visible>!ListItem.IsParentFolder</visible>
 				<visible>[Container.Content(movies) | Container.Content(tvshows)]</visible>
-				<visible>Skin.HasSetting(503.InfoPanel) + System.IdleTime(1)</visible>
+				<visible>Skin.HasSetting(503.InfoPanel) + Control.HasFocus(503) + System.IdleTime(1)</visible>
 				<animation effect="fade" time="100" delay="200">Visible</animation>
 				<animation effect="slide" end="0,460" time="300" tween="cubic" easing="inout" condition="Container(503).Row(1)">Conditional</animation>
 				<animation effect="slide" end="320,0" time="300" tween="cubic" easing="inout" condition="Container(503).Column(5)">Conditional</animation>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -852,7 +852,7 @@ msgid "[B]CONFIGURE PLAYER SETTINGS[/B][CR][CR]Configure video playback · Confi
 msgstr ""
 
 msgctxt "#31415"
-msgid "[B]CONFIGURE LIBRARY SETTINGS[/B][CR][CR]Set default select action · Configure file list options · Configure metadata options[CR]Manage databases"
+msgid "[B]CONFIGURE MEDIA SETTINGS[/B][CR][CR]Set default select action · Configure file list options · Configure metadata options[CR]Manage databases"
 msgstr ""
 
 msgctxt "#31421"


### PR DESCRIPTION
@BigNoid Not sure if we need to change it to a different one but the localized On string is not appearing, like for the InfoPanel as an example.