### PR TITLE
Fix playlist sidemenu slide animation on first open

### DIFF
--- a/1080i/MyPlaylist.xml
+++ b/1080i/MyPlaylist.xml
@@ -4,6 +4,7 @@
 	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<menucontrol>9051</menucontrol>
+	<onload>ClearProperty(MediaMenu,Home)</onload>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">

--- a/21x9/MyPlaylist.xml
+++ b/21x9/MyPlaylist.xml
@@ -4,6 +4,7 @@
 	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<menucontrol>9051</menucontrol>
+	<onload>ClearProperty(MediaMenu,Home)</onload>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">


### PR DESCRIPTION
@BigNoid This has been bugging me for awhile, since Gotham I think. It is the longest running bug that I couldn't see the solution for. So happy I found the cause but disappointed that it took me so long... I thought it was just a weird bug for the playlist window that never got fixed in each Kodi update :smiley:

Edit: Forgot 21:9 again, I just added it now :wink: 