### PR TITLE
Change image id (breaks any button with id of 200)

### DIFF
--- a/1080i/DialogAddonSettings.xml
+++ b/1080i/DialogAddonSettings.xml
@@ -110,7 +110,7 @@
 				<onright>9</onright>
 				<onup>9001</onup>
 				<ondown>9001</ondown>
-				<control type="image" id="200">
+				<control type="image" id="2000">
 					<width>310</width>
 					<height>300</height>
 					<aspectratio>scale</aspectratio>


### PR DESCRIPTION
There seems to be a few add-ons that use 200 as a standard button id and it breaks the functionality of that button so I changed the image id to 2000 instead.

For example if you use openweathermap extended and click location 1 it will prevent DialogKeyboard from opening.