### PR TITLE
fix missing screenshot reference

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -90,6 +90,7 @@
 			<screenshot>resources/screenshot-06.jpg</screenshot>
 			<screenshot>resources/screenshot-07.jpg</screenshot>
 			<screenshot>resources/screenshot-08.jpg</screenshot>
+			<screenshot>resources/screenshot-09.jpg</screenshot>
 		</assets>
 	</extension>
 </addon>


### PR DESCRIPTION
Looks much nicer with the 9th screenshot referenced ;)

![aeon](https://cloud.githubusercontent.com/assets/1050512/21259208/56fe12e2-c378-11e6-990c-df956de2b3ac.jpg)
