### PR TITLE
better visibility for PVR entries in sb-menu

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -170,6 +170,7 @@
 					<textwidth>255</textwidth>
 					<include>ButtonCommonValues</include>
 					<label />
+					<visible>Window.IsActive(MyPVRChannels.xml) | Window.IsActive(MyPVRGuide.xml)</visible>
 				</control>
 				<control type="button" id="2">
 					<description>View As button</description>
@@ -209,6 +210,7 @@
 					<include>ButtonCommonValues</include>
 					<onclick condition="String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(TVChannels)</onclick>
 					<onclick condition="!String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(RadioChannels)</onclick>
+					<visible>!Window.IsActive(MyPVRChannels.xml)</visible>
 				</control>
 				<control type="button" id="101">
 					<description>Guide</description>
@@ -217,6 +219,7 @@
 					<include>ButtonCommonValues</include>
 					<onclick condition="String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(TVGuide)</onclick>
 					<onclick condition="!String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(RadioGuide)</onclick>
+					<visible>!Window.IsActive(MyPVRGuide.xml)</visible>
 				</control>
 				<control type="button" id="102">
 					<description>Recordings</description>
@@ -225,6 +228,7 @@
 					<include>ButtonCommonValues</include>
 					<onclick condition="String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(TVRecordings)</onclick>
 					<onclick condition="!String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(RadioRecordings)</onclick>
+					<visible>!Window.IsActive(MyPVRRecordings.xml)</visible>
 				</control>
 				<control type="button" id="103">
 					<description>Timers</description>
@@ -233,6 +237,7 @@
 					<include>ButtonCommonValues</include>
 					<onclick condition="String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(TVTimers)</onclick>
 					<onclick condition="!String.IsEmpty(Window.Property(IsRadio))">ActivateWindow(RadioTimers)</onclick>
+					<visible>!Window.IsActive(MyPVRTimers.xml)</visible>
 				</control>
 				<control type="button" id="104">
 					<description>Search</description>


### PR DESCRIPTION
This adds some visible-tags to PVR-sideblade menu, e.g.
"Channels" is only visible, if you are not in MyPVRChannels,
"Recordings" is only visible, i you are not in MyPVRRecordings,
and so on ...

"Channel goups" is only visible in MyPVRChannels and MyPVRGuide. It is IMHO
not needed in other PVR windows.

BTW: can you please backport this and the previous PR to krypton ;)
Thx