### PR TITLE
VAR fix for empty PlotOutline in Wall InfoPanel

### DIFF
--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -715,8 +715,8 @@
 		<value>$LOCALIZE[15020]</value>
 	</variable>
 	<variable name="503.InfoPanelTextboxVar">
-		<value condition="Container.Content(movies)">$INFO[ListItem.PlotOutline]</value>
-		<value condition="Container.Content(tvshows)">$INFO[ListItem.Plot]</value>
+		<value condition="!String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
+		<value>$INFO[ListItem.Plot]</value>
 	</variable>
 	<variable name="503.InfoPanelLabel2Var">
 		<value condition="Container.Content(movies)">$INFO[ListItem.Director,$LOCALIZE[31000] ]</value>
@@ -725,11 +725,11 @@
 	<variable name="58.Label2Var">
 		<value condition="Skin.HasSetting(Banner.Wall)">$LOCALIZE[31166]</value>
 		<value>$LOCALIZE[535]</value>
-	</variable> 
+	</variable>
 	<variable name="VideoHWDecoderVar">
 		<value condition="Player.Process(videohwdecoder)">$LOCALIZE[19074]</value>
 		<value>$LOCALIZE[31172]</value>
-	</variable>	
+	</variable>
 	<variable name="SimilarShowsIDVar">
 		<value condition="String.IsEqual(ListItem.DBType,episode)">name=$INFO[ListItem.TvShowTitle]</value>
 		<value>dbid=$INFO[ListItem.DBID]</value>
@@ -738,7 +738,7 @@
 		<value condition="Container.Content(tags)">title</value>
 		<value condition="String.EndsWith(Container(50).ListItem.FolderPath,.xsp)">-</value>
 		<value>year</value>
-	</variable>	
+	</variable>
 	<variable name="ListContentVar">
 		<value condition="String.IsEmpty(Container.PluginName)">$INFO[Container(50).ListItem.FolderPath]</value>
 		<value></value>


### PR DESCRIPTION
When PlotOutline is empty then no Plot is shown for movies so I changed the VAR to fallback to plot when outline IsEmpty