### PR TITLE
Subchannels

### DIFF
--- a/1080i/Includes_LiveTV.xml
+++ b/1080i/Includes_LiveTV.xml
@@ -61,7 +61,7 @@
 				<height>100</height>
 				<font>font65</font>
 				<textcolor>themecolor</textcolor>
-				<label>$INFO[VideoPlayer.ChannelNumber]</label>
+				<label>$INFO[VideoPlayer.ChannelNumberLabel]</label>
 				<scroll>true</scroll>
 			</control>
 			<control type="label" id="1">
@@ -609,7 +609,7 @@
 				<height>68</height>
 				<font>font65</font>
 				<textcolor>themecolor</textcolor>
-				<label>$INFO[VideoPlayer.ChannelNumber]</label>
+				<label>$INFO[VideoPlayer.ChannelNumberLabel]</label>
 				<scroll>true</scroll>
 			</control>
 			<control type="label" id="1">

--- a/1080i/Includes_LiveTV_Views.xml
+++ b/1080i/Includes_LiveTV_Views.xml
@@ -56,7 +56,7 @@
 						<align>center</align>
 						<textcolor>grey2</textcolor>
 						<selectedcolor>selected</selectedcolor>
-						<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="label">
 						<posx>60</posx>
@@ -119,7 +119,7 @@
 						<font>font15</font>
 						<align>center</align>
 						<selectedcolor>selected</selectedcolor>
-						<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="label" id="1">
 						<posx>60</posx>
@@ -402,7 +402,7 @@
 						<font>font14</font>
 						<textcolor>grey2</textcolor>
 						<selectedcolor>selected</selectedcolor>
-						<label>$INFO[ListItem.ChannelNumber]</label>
+						<label>$INFO[ListItem.ChannelNumberLabel]</label>
 					</control>
 					<control type="label">
 						<posx>50</posx>
@@ -448,7 +448,7 @@
 						<height>55</height>
 						<font>font14</font>
 						<selectedcolor>selected</selectedcolor>
-						<label>$INFO[ListItem.ChannelNumber]</label>
+						<label>$INFO[ListItem.ChannelNumberLabel]</label>
 					</control>
 					<control type="label">
 						<posx>50</posx>
@@ -687,7 +687,7 @@
 						<textcolor>white</textcolor>
 						<selectedcolor>themecolor</selectedcolor>
 						<font>font14_textbox</font>
-						<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="progress">
 						<left>70</left>
@@ -742,7 +742,7 @@
 						<textcolor>white</textcolor>
 						<selectedcolor>white</selectedcolor>
 						<font>font14_textbox</font>
-						<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="progress">
 						<left>70</left>
@@ -981,7 +981,7 @@
 					<textcolor>grey2</textcolor>
 					<selectedcolor>selected</selectedcolor>
 					<align>center</align>
-					<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+					<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 				</control>
 				<control type="label">
 					<left>130</left>
@@ -1058,7 +1058,7 @@
 					<font>font45caps_title</font>
 					<selectedcolor>white</selectedcolor>
 					<align>center</align>
-					<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+					<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 				</control>
 				<control type="label">
 					<left>130</left>

--- a/1080i/Includes_LiveTV_Views.xml
+++ b/1080i/Includes_LiveTV_Views.xml
@@ -50,7 +50,7 @@
 						<texture border="1">separator2.png</texture>
 					</control>
 					<control type="label">
-						<width>60</width>
+						<width>75</width>
 						<height>60</height>
 						<font>font15</font>
 						<align>center</align>
@@ -59,8 +59,8 @@
 						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="label">
-						<posx>60</posx>
-						<width>400</width>
+						<posx>75</posx>
+						<width>385</width>
 						<height>60</height>
 						<font>font15</font>
 						<textoffsetx>15</textoffsetx>
@@ -70,8 +70,8 @@
 						<visible>String.IsEmpty(ListItem.Icon) | String.IsEmpty(Skin.String(LiveTV.EpgViewChannels))</visible>
 					</control>
 					<control type="label">
-						<posx>138</posx>
-						<width>300</width>
+						<posx>153</posx>
+						<width>285</width>
 						<height>60</height>
 						<font>font15</font>
 						<textoffsetx>15</textoffsetx>
@@ -81,7 +81,7 @@
 						<visible>String.IsEqual(Skin.String(LiveTV.EpgViewChannels),2) + !String.IsEmpty(ListItem.Icon)</visible>
 					</control>
 					<control type="image">
-						<posx>70</posx>
+						<posx>75</posx>
 						<posy>2</posy>
 						<width>65</width>
 						<height>56</height>
@@ -91,7 +91,7 @@
 						<visible>String.IsEqual(Skin.String(LiveTV.EpgViewChannels),2) + !String.IsEmpty(ListItem.Icon)</visible>
 					</control>
 					<control type="image">
-						<posx>70</posx>
+						<posx>75</posx>
 						<posy>1</posy>
 						<width>200</width>
 						<height>58</height>
@@ -114,7 +114,7 @@
 						<texture border="4">listselect_fo.png</texture>
 					</control>
 					<control type="label">
-						<width>60</width>
+						<width>75</width>
 						<height>60</height>
 						<font>font15</font>
 						<align>center</align>
@@ -122,8 +122,8 @@
 						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="label" id="1">
-						<posx>60</posx>
-						<width>380</width>
+						<posx>75</posx>
+						<width>365</width>
 						<height>60</height>
 						<font>font15</font>
 						<textoffsetx>15</textoffsetx>
@@ -132,8 +132,8 @@
 						<visible>String.IsEmpty(Skin.String(LiveTV.EpgViewChannels)) | String.IsEmpty(ListItem.Icon)</visible>
 					</control>
 					<control type="label">
-						<posx>138</posx>
-						<width>300</width>
+						<posx>153</posx>
+						<width>285</width>
 						<height>60</height>
 						<font>font15</font>
 						<textoffsetx>15</textoffsetx>
@@ -142,7 +142,7 @@
 						<visible>String.IsEqual(Skin.String(LiveTV.EpgViewChannels),2) + !String.IsEmpty(ListItem.Icon)</visible>
 					</control>
 					<control type="image">
-						<posx>70</posx>
+						<posx>75</posx>
 						<posy>2</posy>
 						<width>65</width>
 						<height>56</height>

--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -56,7 +56,7 @@
 					<control type="label">
 						<width>120</width>
 						<height>95</height>
-						<font>font45caps_title</font>
+						<font>font35_title_bold</font>
 						<textcolor>grey2</textcolor>
 						<selectedcolor>selected</selectedcolor>
 						<align>center</align>
@@ -147,7 +147,7 @@
 					<control type="label">
 						<width>120</width>
 						<height>95</height>
-						<font>font45caps_title</font>
+						<font>font35_title_bold</font>
 						<selectedcolor>selected</selectedcolor>
 						<align>center</align>
 						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>

--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -688,7 +688,7 @@
 							</control>
 							<control type="label">
 								<left>2</left>
-								<width>55</width>
+								<width>67</width>
 								<height>63</height>
 								<align>right</align>
 								<textcolor>white</textcolor>
@@ -697,9 +697,9 @@
 								<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 							</control>
 							<control type="progress">
-								<left>70</left>
+								<left>80</left>
 								<top>25</top>
-								<width>80</width>
+								<width>70</width>
 								<height>12</height>
 								<info>ListItem.Progress</info>
 								<visible>!String.IsEqual(ListItem.Title,)</visible>
@@ -744,7 +744,7 @@
 							</control>
 							<control type="label">
 								<left>2</left>
-								<width>55</width>
+								<width>67</width>
 								<height>63</height>
 								<align>right</align>
 								<textcolor>white</textcolor>
@@ -753,9 +753,9 @@
 								<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 							</control>
 							<control type="progress">
-								<left>70</left>
+								<left>80</left>
 								<top>25</top>
-								<width>80</width>
+								<width>70</width>
 								<height>12</height>
 								<info>ListItem.Progress</info>
 								<visible>!String.IsEqual(ListItem.Title,)</visible>

--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -60,7 +60,7 @@
 						<textcolor>grey2</textcolor>
 						<selectedcolor>selected</selectedcolor>
 						<align>center</align>
-						<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="label">
 						<left>130</left>
@@ -150,7 +150,7 @@
 						<font>font45caps_title</font>
 						<selectedcolor>selected</selectedcolor>
 						<align>center</align>
-						<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 					</control>
 					<control type="label">
 						<left>130</left>
@@ -395,7 +395,7 @@
 						<font>font13b</font>
 						<textcolor>grey</textcolor>
 						<selectedcolor>selected</selectedcolor>
-						<label>[B]$INFO[ListItem.ChannelNumber]  $INFO[ListItem.Label][/B]</label>
+						<label>[B]$INFO[ListItem.ChannelNumberLabel]  $INFO[ListItem.Label][/B]</label>
 					</control>
 					<control type="image">
 						<left>335</left>
@@ -478,7 +478,7 @@
 							<height>58</height>
 							<font>font13b</font>
 							<selectedcolor>selected</selectedcolor>
-							<label>[B]$INFO[ListItem.ChannelNumber]  $INFO[ListItem.Label][/B]</label>
+							<label>[B]$INFO[ListItem.ChannelNumberLabel]  $INFO[ListItem.Label][/B]</label>
 						</control>
 						<control type="group">
 							<left>15</left>
@@ -694,7 +694,7 @@
 								<textcolor>white</textcolor>
 								<selectedcolor>themecolor</selectedcolor>
 								<font>font14_textbox</font>
-								<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+								<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 							</control>
 							<control type="progress">
 								<left>70</left>
@@ -750,7 +750,7 @@
 								<textcolor>white</textcolor>
 								<selectedcolor>white</selectedcolor>
 								<font>font14_textbox</font>
-								<label>[B]$INFO[ListItem.ChannelNumber][/B]</label>
+								<label>[B]$INFO[ListItem.ChannelNumberLabel][/B]</label>
 							</control>
 							<control type="progress">
 								<left>70</left>


### PR DESCRIPTION
Address https://github.com/BigNoid/Aeon-Nox/issues/680 by displaying Sub Channels by using "ChannelNumberLabel" instead of "ChannelNumber" - with additional changes to accommodate spacing

Simply changing the label:-

![changed_label](https://user-images.githubusercontent.com/1839810/29635011-968f1006-8843-11e7-952d-ba583e2644d7.png)

And Reszing:-

![changed_label_and_size](https://user-images.githubusercontent.com/1839810/29635010-9689e36a-8843-11e7-836d-1ce08d649d8b.png)
