### PR TITLE
Add LowList support for Music Videos

### DIFF
--- a/1080i/View_501_LowList.xml
+++ b/1080i/View_501_LowList.xml
@@ -35,7 +35,14 @@
 					<label>[COLOR labelheader]$LOCALIZE[31000]:[/COLOR][CR]$INFO[ListItem.Director]</label>
 					<width>650</width>
 					<include>ShowCaseInfoPanelButtonsValues</include>
-					<visible>!String.IsEmpty(ListItem.Director) + Container.Content(movies)</visible>
+					<visible>!String.IsEmpty(ListItem.Director) + ( Container.Content(movies)| Container.Content(musicvideos) )</visible>
+				</control>
+				<control type="button">
+					<label>[COLOR labelheader]$LOCALIZE[558]:[/COLOR][CR]$INFO[ListItem.Album]</label>
+					<width>650</width>
+					<include>ShowCaseInfoPanelButtonsValues</include>
+					<include>VisibleFadeAnimation</include>
+					<visible>!String.IsEmpty(ListItem.Album) + Container.Content(musicvideos)</visible>
 				</control>
 				<control type="button">
 					<label>[COLOR labelheader]$LOCALIZE[20416]:[/COLOR][CR]$INFO[ListItem.Premiered]</label>
@@ -50,6 +57,13 @@
 					<include>ShowCaseInfoPanelButtonsValues</include>
 					<include>VisibleFadeAnimation</include>
 					<visible>!String.IsEmpty(ListItem.Studio) + Container.Content(episodes)</visible>
+				</control>
+				<control type="button">
+					<label>[COLOR labelheader]$LOCALIZE[21899]:[/COLOR][CR]$INFO[ListItem.Studio]</label>
+					<width>650</width>
+					<include>ShowCaseInfoPanelButtonsValues</include>
+					<include>VisibleFadeAnimation</include>
+					<visible>!String.IsEmpty(ListItem.Studio) + Container.Content(musicvideos)</visible>
 				</control>
 				<control type="button">
 					<label>[COLOR labelheader]$LOCALIZE[515]:[/COLOR][CR]$INFO[ListItem.Genre]</label>
@@ -76,7 +90,7 @@
 				<fadetime>IconCrossfadeTime</fadetime>
 				<bordertexture border="2">thumbs/panel_border3.png</bordertexture>
 				<bordersize>2</bordersize>
-				<visible>Container.Content(episodes)</visible>
+				<visible>Container.Content(episodes) | Container.Content(musicvideos)</visible>
 				<animation effect="slide" end="0,-170" time="120" condition="!Skin.HasSetting(nohighlist)">Conditional</animation>
 			</control>
 			<control type="group">
@@ -322,7 +336,7 @@
 				<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(musicvideos)</visible>
 				<scrolltime tween="quadratic" easing="out">200</scrolltime>
 				<animation effect="slide" end="0,-170" time="120" condition="!Skin.HasSetting(nohighlist)">Conditional</animation>
-				<itemlayout height="68" width="806" condition="Container.Content(movies)">
+				<itemlayout height="68" width="806" condition="Container.Content(movies) | Container.Content(musicvideos)">
 					<control type="image">
 						<top>8</top>
 						<width>806</width>
@@ -368,7 +382,7 @@
 						<texture>$VAR[ListItem.Overlay]</texture>
 					</control>
 				</itemlayout>
-				<focusedlayout height="68" width="806" condition="Container.Content(movies)">
+				<focusedlayout height="68" width="806" condition="Container.Content(movies) | Container.Content(musicvideos)">
 					<control type="image">
 						<top>8</top>
 						<width>806</width>

--- a/1080i/View_501_LowList.xml
+++ b/1080i/View_501_LowList.xml
@@ -319,7 +319,7 @@
 				<ondown>501</ondown>
 				<pagecontrol>50160</pagecontrol>
 				<viewtype label="LowList">list</viewtype>
-				<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)</visible>
+				<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(musicvideos)</visible>
 				<scrolltime tween="quadratic" easing="out">200</scrolltime>
 				<animation effect="slide" end="0,-170" time="120" condition="!Skin.HasSetting(nohighlist)">Conditional</animation>
 				<itemlayout height="68" width="806" condition="Container.Content(movies)">

--- a/1080i/custom_1129_Views.xml
+++ b/1080i/custom_1129_Views.xml
@@ -72,7 +72,7 @@
 				<item>
 					<label>LowList</label>
 					<onclick>Container.SetViewMode(501)</onclick>
-					<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)</visible>
+					<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(musicvideos)</visible>
 				</item>
 				<item>
 					<label>LowList</label>


### PR DESCRIPTION
Activate Low List support for Music Videos, and choose suitable fields for the right hand side.

Low List
![screenshot013](https://user-images.githubusercontent.com/1839810/29729653-efafdf48-89d4-11e7-84ca-3e5c01a27f6d.png)

and Low List low toggle
![screenshot016](https://user-images.githubusercontent.com/1839810/29729716-2c24247a-89d5-11e7-859d-c263390b5cff.png)

and Dialogue Information
![screenshot015](https://user-images.githubusercontent.com/1839810/29729652-efac5a12-89d4-11e7-9b30-3b60c20cb1e9.png)



