### PR TITLE
Update string used for Reset label

### DIFF
--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -352,7 +352,7 @@
 						<height>90</height>
 						<textoffsetx>30</textoffsetx>
 						<font>font15</font>
-						<label>- $LOCALIZE[10035]</label>
+						<label>- $LOCALIZE[13007]</label>
 						<onclick>Skin.Reset(VideoGenreFanartPath)</onclick>
 						<texturenofocus border="1">separator5.png</texturenofocus>
 						<visible>!String.IsEmpty(Skin.String(VideoGenreFanartPath))</visible>
@@ -372,7 +372,7 @@
 						<height>90</height>
 						<textoffsetx>30</textoffsetx>
 						<font>font15</font>
-						<label>- $LOCALIZE[10035]</label>
+						<label>- $LOCALIZE[13007]</label>
 						<onclick>Skin.Reset(MusicGenreFanartPath)</onclick>
 						<texturenofocus border="1">separator5.png</texturenofocus>
 						<visible>!String.IsEmpty(Skin.String(MusicGenreFanartPath))</visible>

--- a/1080i/custom_1121_HomeMenuCustomizer.xml
+++ b/1080i/custom_1121_HomeMenuCustomizer.xml
@@ -279,7 +279,7 @@
 					<height>90</height>
 					<textoffsetx>30</textoffsetx>
 					<font>font15</font>
-					<label>$LOCALIZE[10035]</label>
+					<label>$LOCALIZE[13007]</label>
 					<texturenofocus border="1">separator5.png</texturenofocus>
 					<onclick>Skin.Reset($INFO[Container(90000).ListItem.Property(Item),,HomeItem.Label])</onclick>
 					<onclick>Skin.Reset($INFO[Container(90000).ListItem.Property(Item),,HomeItem.Path])</onclick>

--- a/1080i/custom_1122_BackgroundCustomizer.xml
+++ b/1080i/custom_1122_BackgroundCustomizer.xml
@@ -90,7 +90,7 @@
 			</focusedlayout>
 			<content>
 				<item>
-					<label>$LOCALIZE[10035]</label>
+					<label>$LOCALIZE[13007]</label>
 					<onclick>Skin.Reset(ItemToEdit.MultiFanart)</onclick>
 					<onclick>Skin.Reset(ItemToEdit.BGType)</onclick>
 					<onclick>Skin.SetString($INFO[Window(Home).Property(Nox.Temp)],$INFO[Skin.String(ItemToEdit.MultiFanart)])</onclick>

--- a/1080i/custom_1123_OnClickCustomizer.xml
+++ b/1080i/custom_1123_OnClickCustomizer.xml
@@ -92,7 +92,7 @@
 			</focusedlayout>
 			<content>
 				<item>
-					<label>$LOCALIZE[10035]</label>
+					<label>$LOCALIZE[13007]</label>
 					<onclick>Skin.Reset(ItemToEdit.Path)</onclick>
 					<onclick>Skin.Reset(ItemToEdit.Label)</onclick>
 					<onclick>Skin.SetString($INFO[Window(Home).Property(Nox.Path)],$INFO[Skin.String(ItemToEdit.Path)])</onclick>


### PR DESCRIPTION
@BigNoid 
[10035 was changed to Skin Settings](https://github.com/xbmc/xbmc/blob/master/addons/resource.language.en_gb/resources/strings.po#L4828).

[Using 13007 instead](https://github.com/xbmc/xbmc/blob/master/addons/resource.language.en_gb/resources/strings.po#L5927).