### PR TITLE
[EventLog] Add width tags to list, layout, and labels

### DIFF
--- a/1080i/EventLog.xml
+++ b/1080i/EventLog.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<menucontrol>9051</menucontrol>
 	<onload>SetProperty(Window.HasSettings,True,home)</onload>
@@ -24,6 +23,7 @@
 						<left>-32</left>
 						<top>1020</top>
 						<right>-32</right>
+						<width>1784</width>
 						<height>904</height>
 						<texture border="40">panel_reflect.png</texture>
 					</control>
@@ -32,11 +32,13 @@
 						<left>-32</left>
 						<top>148</top>
 						<right>-32</right>
+						<width>1784</width>
 						<height>904</height>
 						<texture border="40">listpanel_back.png</texture>
 					</control>
 					<control type="list" id="50">
 						<top>180</top>
+						<width>1720</width>
 						<height>840</height>
 						<onleft>SetProperty(MediaMenu,True,home)</onleft>
 						<onleft>SetFocus(9050)</onleft>
@@ -46,7 +48,7 @@
 						<viewtype label="535">list</viewtype>
 						<pagecontrol>60</pagecontrol>
 						<scrolltime tween="quadratic" easing="out">200</scrolltime>
-						<itemlayout height="120">
+						<itemlayout height="120" width="1720">
 							<control type="image">
 								<top>60</top>
 								<height>60</height>
@@ -74,6 +76,7 @@
 							<control type="label">
 								<left>135</left>
 								<right>20</right>
+								<width>1565</width>
 								<height>70</height>
 								<font>font30</font>
 								<textcolor>grey2</textcolor>
@@ -85,6 +88,7 @@
 								<left>135</left>
 								<top>50</top>
 								<right>20</right>
+								<width>1565</width>
 								<height>60</height>
 								<font>font15</font>
 								<textcolor>grey3</textcolor>
@@ -94,6 +98,7 @@
 							<control type="label">
 								<left>135</left>
 								<right>20</right>
+								<width>1565</width>
 								<height>120</height>
 								<font>font15</font>
 								<align>right</align>
@@ -102,7 +107,7 @@
 								<label>$INFO[ListItem.Label2]</label>
 							</control>
 						</itemlayout>
-						<focusedlayout height="120">
+						<focusedlayout height="120" width="1720">
 							<control type="image">
 								<top>60</top>
 								<height>60</height>
@@ -135,6 +140,7 @@
 							<control type="label">
 								<left>135</left>
 								<right>20</right>
+								<width>1565</width>
 								<height>70</height>
 								<font>font30</font>
 								<textcolor>white</textcolor>
@@ -147,6 +153,7 @@
 								<left>135</left>
 								<top>50</top>
 								<right>20</right>
+								<width>1565</width>
 								<height>60</height>
 								<font>font15</font>
 								<textcolor>white</textcolor>
@@ -157,6 +164,7 @@
 							<control type="label">
 								<left>135</left>
 								<right>20</right>
+								<width>1565</width>
 								<height>120</height>
 								<font>font15</font>
 								<align>right</align>


### PR DESCRIPTION
@BigNoid This fixes an issue reported on Kodi **[forums](https://forum.kodi.tv/showthread.php?tid=183504&pid=2692457#pid2692457)**

Edit: Looking over Git history... This may not be the correct approach cause I think **[here](https://github.com/BigNoid/Aeon-Nox/commit/dcd5676c78da03d61915fcf21683f338b8ddf01b#diff-9a2e10c231bab8fedc36c7848f32e30c)** you did this change for the 21:9 layout?

Edit 2: Looks like this could only be a Krypton thing. I can close this and make for Krypton or would you prefer to cherrypick instead?