### PR TITLE
Add OSDSubtitleSettings button

### DIFF
--- a/1080i/DialogSettings.xml
+++ b/1080i/DialogSettings.xml
@@ -4,7 +4,7 @@
 	<include>DialogOpenCloseAnimation</include>
 	<controls>
 		<control type="group">
-			<animation effect="fade" start="100" end="0" time="400" condition="Window.IsVisible(SliderDialog)">Conditional</animation>
+			<animation effect="fade" start="100" end="0" time="400" condition="Window.IsVisible(SliderDialog) | Window.IsVisible(SubtitleSearch)">Conditional</animation>
 			<width>1522</width>
 			<height>660</height>
 			<centerleft>50%</centerleft>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -20,7 +20,7 @@
 			<visible>!VideoPlayer.Content(LiveTV)</visible>
 		</control>
 		<control type="group">
-			<animation effect="slide" end="0,-238" time="240" tween="quadratic" condition="Window.IsVisible(SliderDialog) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(PVROSDTeletext) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)">Conditional</animation>
+			<animation effect="slide" end="0,-238" time="240" tween="quadratic" condition="Window.IsVisible(SliderDialog) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(PVROSDTeletext) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(OSDSubtitleSettings) | Window.IsVisible(VideoBookmarks)">Conditional</animation>
 			<animation effect="slide" start="0,-238" end="0,0" time="240" tween="quadratic">WindowOpen</animation>
 			<animation effect="slide" end="0,-238" start="0,0" time="240" tween="quadratic">WindowClose</animation>
 			<control type="image">
@@ -134,8 +134,7 @@
 					<width>100</width>
 					<height>100</height>
 					<font />
-					<onclick>Close</onclick>
-					<onclick>ActivateWindow(SubtitleSearch)</onclick>
+					<onclick>ActivateWindow(osdsubtitlesettings)</onclick>
 				</control>
 				<control type="button" id="704">
 					<texturefocus>osd/buttons/OSDDvdFO.png</texturefocus>


### PR DESCRIPTION
@BigNoid I couldn't find a better button for the new subtitles settings dialog so I changed the onclick to open that instead. The new dialog has a Download subtitles button so I added a condition to the fade animation that already hides DialogSettings when SliderDialog is visible.